### PR TITLE
Fix root install retry for KernelSU forks (SukiSU Ultra)

### DIFF
--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/root/RootServiceManager.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/root/RootServiceManager.kt
@@ -49,6 +49,7 @@ class RootServiceManager(
         configureDefaultShell()
         scope.launch(Dispatchers.IO) {
             Logger.d(TAG) { "requestPermission() — forcing main shell creation" }
+            dropStaleNonRootShell()
             try {
                 val shell = Shell.getShell()
                 Logger.d(TAG) { "requestPermission() — shell rootStatus=${shell.status}" }
@@ -56,6 +57,23 @@ class RootServiceManager(
                 Logger.w(TAG) { "requestPermission() — getShell failed: ${e.javaClass.simpleName}: ${e.message}" }
             }
             refreshStatusBlocking()
+        }
+    }
+
+    // libsu caches the main shell and only rebuilds it once it dies (status < 0). A non-root
+    // shell stays cached at status 0, so a single failed probe makes Shell.getShell() keep
+    // returning that non-root shell forever — retry becomes impossible without killing the
+    // process. kprobe-based su managers (KernelSU / SukiSU / APatch) can transiently deny the
+    // first probe (grant prompt timeout, app profile not yet applied), so we close a stale
+    // non-root shell here to force libsu to re-exec `su` on the next getShell() (GH#693).
+    private fun dropStaleNonRootShell() {
+        try {
+            Shell.getCachedShell()?.takeIf { !it.isRoot }?.let {
+                Logger.d(TAG) { "dropStaleNonRootShell() — closing cached non-root shell to force re-probe" }
+                it.close()
+            }
+        } catch (e: Exception) {
+            Logger.w(TAG) { "dropStaleNonRootShell() — close failed: ${e.message}" }
         }
     }
 
@@ -192,7 +210,7 @@ class RootServiceManager(
         private const val KEY_GRANTED_BEFORE = "root_granted_before"
         private const val STATUS_SUCCESS = 0
         private const val STATUS_FAILURE = -1
-        private const val SHELL_TIMEOUT_SECONDS = 10L
+        private const val SHELL_TIMEOUT_SECONDS = 20L
 
         private val PACKAGE_NAME_PATTERN =
             Regex("""^[A-Za-z][A-Za-z0-9_]*(\.[A-Za-z][A-Za-z0-9_]*)+$""")

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/22.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/22.json
@@ -9,6 +9,12 @@
       "bullets": [
         "Traditional Chinese (繁體中文) is now available — switch to it anytime under Tweaks → Language."
       ]
+    },
+    {
+      "type": "FIXED",
+      "bullets": [
+        "Root install now works with KernelSU-based managers like SukiSU Ultra and APatch — root is re-checked properly and you can retry granting access if the first attempt doesn't take."
+      ]
     }
   ]
 }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/zh-TW/22.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/zh-TW/22.json
@@ -9,6 +9,12 @@
       "bullets": [
         "現已支援繁體中文 — 隨時可在「設定 → 語言」中切換。"
       ]
+    },
+    {
+      "type": "FIXED",
+      "bullets": [
+        "Root 安裝現已支援以 KernelSU 為基礎的管理器，例如 SukiSU Ultra 與 APatch — 系統會正確重新偵測 Root 權限，若首次授權未生效也可再次嘗試。"
+      ]
     }
   ]
 }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Installation.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Installation.kt
@@ -309,7 +309,10 @@ private fun RootActions(availability: RootAvailability, onRequest: () -> Unit) {
     when (availability) {
         RootAvailability.PERMISSION_NEEDED ->
             ActionButton(stringResource(Res.string.root_grant_permission), onRequest)
-        RootAvailability.UNAVAILABLE -> HintRow(stringResource(Res.string.root_unavailable_hint))
+        RootAvailability.UNAVAILABLE -> {
+            HintRow(stringResource(Res.string.root_unavailable_hint))
+            ActionButton(stringResource(Res.string.retry), onRequest)
+        }
         RootAvailability.READY -> Unit
     }
 }


### PR DESCRIPTION
Closes #693.

SukiSU Ultra / KernelSU expose a kprobe-hooked virtual `su`, so libsu's passive PATH scan returns `false` and `exec("su")` can transiently fail on first probe. libsu then caches that non-root shell permanently, and the UNAVAILABLE UI showed no retry — a dead-end.

Fix:
- Close stale non-root cached shell before re-probing, forcing libsu to re-`exec("su")`.
- Add Retry button to the UNAVAILABLE state.
- Bump shell timeout 10s to 20s for grant-prompt latency.
- Whatsnew note (1.9.3).

Not reproducible here; needs testing on a KernelSU/SukiSU device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved root-related install flows so root access is rechecked correctly and failed attempts can be retried.
  - Fixed cases where root detection could get stuck after a denied or non-root shell session, helping root actions recover properly.
  - Added a retry option when root is unavailable, making it easier to attempt authorization again.
- **Documentation**
  - Updated “What’s New” notes to reflect the improved root install experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->