### PR TITLE
Fix: prevent info badge text from overlapping and add ellipsis for lo…

### DIFF
--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/StatItem.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/StatItem.kt
@@ -15,6 +15,7 @@ import zed.rainxch.core.presentation.components.text.KomiText
 import zed.rainxch.core.presentation.components.text.KomiTextRole
 import zed.rainxch.core.presentation.locals.LocalPersonality
 import zed.rainxch.core.presentation.utils.formatCount
+import androidx.compose.ui.text.style.TextOverflow
 
 @Composable
 fun StatItem(
@@ -55,7 +56,10 @@ fun StatItem(
             fontSize = 22.sp,
             fontWeight = FontWeight.Black,
             color = colors.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
             uppercase = false,
+            
         )
     }
 }
@@ -91,6 +95,7 @@ fun TextStatItem(
             fontWeight = FontWeight.Black,
             color = colors.onSurface,
             maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
             uppercase = false,
         )
     }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Stats.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Stats.kt
@@ -46,6 +46,7 @@ fun LazyListScope.stats(
         }
 
         Row(
+            modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
@@ -69,6 +70,7 @@ fun LazyListScope.stats(
         Spacer(Modifier.height(10.dp))
 
         Row(
+            modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {


### PR DESCRIPTION
Fixes #863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Long statistic titles now display an ellipsis when they exceed the available space, improving readability and preventing overflow.
  * Updated the statistics rows to better use the full available width for improved layout consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->