### PR TITLE
feat: support bare GitHub repository searches

### DIFF
--- a/feature/search/presentation/build.gradle.kts
+++ b/feature/search/presentation/build.gradle.kts
@@ -17,5 +17,10 @@ kotlin {
                 implementation(libs.jetbrains.compose.components.resources)
             }
         }
+        commonTest {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
     }
 }

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
@@ -53,8 +53,9 @@ import zed.rainxch.search.presentation.mappers.toDomain
 import zed.rainxch.search.presentation.model.ProgrammingLanguageUi
 import zed.rainxch.search.presentation.model.SearchSourceUi
 import zed.rainxch.search.presentation.model.SortByUi
-import zed.rainxch.search.presentation.utils.isEntirelyGithubUrls
+import zed.rainxch.search.presentation.utils.isEntirelyGithubSearchInput
 import zed.rainxch.search.presentation.utils.parseGithubUrls
+import zed.rainxch.search.presentation.utils.parseGithubSearchInput
 
 class SearchViewModel(
     private val searchRepository: SearchRepository,
@@ -574,7 +575,7 @@ class SearchViewModel(
             }
 
             is SearchAction.OnSearchChange -> {
-                val links = parseGithubUrls(action.query)
+                val links = parseGithubSearchInput(action.query)
                 _state.update {
                     it.copy(
                         query = action.query,
@@ -593,7 +594,7 @@ class SearchViewModel(
                             totalCount = null,
                         )
                     }
-                } else if (isEntirelyGithubUrls(action.query)) {
+                } else if (isEntirelyGithubSearchInput(action.query)) {
                     currentSearchJob?.cancel()
                     _state.update {
                         it.copy(
@@ -620,7 +621,10 @@ class SearchViewModel(
             }
 
             SearchAction.OnSearchImeClick -> {
-                if (_state.value.detectedLinks.isNotEmpty() && isEntirelyGithubUrls(_state.value.query)) {
+                if (
+                    _state.value.detectedLinks.isNotEmpty() &&
+                    isEntirelyGithubSearchInput(_state.value.query)
+                ) {
                     val link = _state.value.detectedLinks.first()
                     viewModelScope.launch {
                         _events.send(SearchEvent.NavigateToRepo(link.owner, link.repo))

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/utils/GithubUrlParser.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/utils/GithubUrlParser.kt
@@ -9,6 +9,11 @@ private val GITHUB_URL_REGEX =
         """(?<![A-Za-z0-9.-])(?:https?://)?(?:www\.)?github\.com/([a-zA-Z0-9\-_.]+)/([a-zA-Z0-9\-_.]+)""",
     )
 
+private val GITHUB_REPOSITORY_REFERENCE_REGEX =
+    Regex(
+        """([a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38})/([a-zA-Z0-9\-_.]+)""",
+    )
+
 fun parseGithubUrls(text: String): ImmutableList<ParsedGithubLink> =
     GITHUB_URL_REGEX
         .findAll(text)
@@ -21,10 +26,31 @@ fun parseGithubUrls(text: String): ImmutableList<ParsedGithubLink> =
         }.distinctBy { "${it.owner}/${it.repo}" }
         .toImmutableList()
 
+fun parseGithubSearchInput(text: String): ImmutableList<ParsedGithubLink> =
+    parseBareGithubRepository(text)
+        ?.let { listOf(it).toImmutableList() }
+        ?: parseGithubUrls(text)
+
 fun isEntirelyGithubUrls(text: String): Boolean {
     val stripped =
         text
             .replace(GITHUB_URL_REGEX, "")
             .replace(Regex("""[\s,;]+"""), "")
     return stripped.isEmpty() && parseGithubUrls(text).isNotEmpty()
+}
+
+fun isEntirelyGithubSearchInput(text: String): Boolean =
+    parseBareGithubRepository(text) != null || isEntirelyGithubUrls(text)
+
+private fun parseBareGithubRepository(text: String): ParsedGithubLink? {
+    val match = GITHUB_REPOSITORY_REFERENCE_REGEX.matchEntire(text.trim()) ?: return null
+    val owner = match.groupValues[1]
+    val repo = match.groupValues[2].removeSuffix(".git")
+    if (repo.length !in 1..100) return null
+
+    return ParsedGithubLink(
+        owner = owner,
+        repo = repo,
+        fullUrl = "https://github.com/$owner/$repo",
+    )
 }

--- a/feature/search/presentation/src/commonTest/kotlin/zed/rainxch/search/presentation/utils/GithubUrlParserTest.kt
+++ b/feature/search/presentation/src/commonTest/kotlin/zed/rainxch/search/presentation/utils/GithubUrlParserTest.kt
@@ -1,0 +1,105 @@
+package zed.rainxch.search.presentation.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import zed.rainxch.search.presentation.model.ParsedGithubLink
+
+class GithubUrlParserTest {
+    @Test
+    fun parsesTrimmedBareRepositoryReferenceForSearch() {
+        val expected =
+            listOf(
+                ParsedGithubLink(
+                    owner = "aa",
+                    repo = "bb",
+                    fullUrl = "https://github.com/aa/bb",
+                ),
+            )
+
+        assertEquals(expected, parseGithubSearchInput("aa/bb"))
+        assertEquals(expected, parseGithubSearchInput(" \t aa/bb.git \n"))
+        assertTrue(isEntirelyGithubSearchInput("aa/bb"))
+        assertTrue(isEntirelyGithubSearchInput(" \t aa/bb.git \n"))
+    }
+
+    @Test
+    fun validatesNormalizedBareRepositoryNameLength() {
+        val repositoryAtLimit = "r".repeat(100)
+        val repositoryOverLimit = "r".repeat(101)
+
+        assertEquals(repositoryAtLimit, parseGithubSearchInput("aa/$repositoryAtLimit").single().repo)
+        assertEquals(repositoryAtLimit, parseGithubSearchInput("aa/$repositoryAtLimit.git").single().repo)
+        assertTrue(parseGithubSearchInput("aa/$repositoryOverLimit").isEmpty())
+        assertTrue(parseGithubSearchInput("aa/$repositoryOverLimit.git").isEmpty())
+    }
+
+    @Test
+    fun keepsClipboardParsingUrlOnly() {
+        assertTrue(parseGithubUrls("aa/bb").isEmpty())
+        assertFalse(isEntirelyGithubUrls("aa/bb"))
+    }
+
+    @Test
+    fun preservesFullGithubUrlBehavior() {
+        assertEquals(
+            listOf(
+                ParsedGithubLink(
+                    owner = "aa",
+                    repo = "bb",
+                    fullUrl = "https://github.com/aa/bb",
+                ),
+            ),
+            parseGithubUrls("https://github.com/aa/bb.git"),
+        )
+        assertTrue(isEntirelyGithubUrls("https://github.com/aa/bb.git"))
+    }
+
+    @Test
+    fun preservesMultipleGithubUrlBehaviorForSearch() {
+        val input = "https://github.com/aa/bb, https://www.github.com/cc/dd.git"
+
+        assertEquals(
+            listOf(
+                ParsedGithubLink(
+                    owner = "aa",
+                    repo = "bb",
+                    fullUrl = "https://github.com/aa/bb",
+                ),
+                ParsedGithubLink(
+                    owner = "cc",
+                    repo = "dd",
+                    fullUrl = "https://github.com/cc/dd",
+                ),
+            ),
+            parseGithubSearchInput(input),
+        )
+        assertTrue(isEntirelyGithubSearchInput(input))
+    }
+
+    @Test
+    fun rejectsInvalidBareRepositoryReferencesForSearch() {
+        val nonMatches =
+            listOf(
+                "https://gitlab.com/aa/bb",
+                "aa/bb/issues",
+                "open aa/bb please",
+                "example.com/repository",
+                "/aa/bb",
+                "aa/bb/",
+                "-aa/bb",
+                "aa-/bb",
+                "aa--bb/repository",
+                "aa_bb/repository",
+                "aa.bb/repository",
+                "${"a".repeat(40)}/bb",
+                "aa/.git",
+            )
+
+        nonMatches.forEach { input ->
+            assertTrue(parseGithubSearchInput(input).isEmpty(), input)
+            assertFalse(isEntirelyGithubSearchInput(input), input)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #880

## Summary

- recognize a trimmed bare `owner/repository` value as a GitHub quick-open search
- keep clipboard detection limited to explicit GitHub URLs
- validate GitHub owner and normalized repository constraints, including the optional `.git` suffix

## Validation

- `./gradlew :feature:search:presentation:jvmTest --tests 'zed.rainxch.search.presentation.utils.GithubUrlParserTest'`
- `./gradlew ktlintCheck`
- `git diff --check`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search now accepts GitHub repository references in `owner/repo` format.
  * Optional `.git` suffixes and surrounding whitespace are handled automatically.
  * Multiple GitHub URLs can be entered together for search.

* **Bug Fixes**
  * Improved validation rejects malformed repository references and invalid repository names.
  * Search and navigation behavior now correctly distinguishes repository references from clipboard URLs.

* **Tests**
  * Added coverage for valid, invalid, normalized, and multi-link search inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->