### PR TITLE
fix: detect updates for nightly and opaque-marker version tags

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
@@ -345,8 +345,13 @@ class InstalledAppsRepositoryImpl(
                     codesAlreadyMatch -> false
                     matchesSkipped -> false
                     opaquePair || (sameTag && !reconcilable) ->
-                        isNewerByTimestamp(matchedRelease, app.latestReleasePublishedAt) ||
-                            (app.isUpdateAvailable && app.latestVersion == matchedRelease.tagName)
+                        VersionMath.shouldReportTimestampUpdate(
+                            matchedTag = matchedRelease.tagName,
+                            matchedPublishedAt = matchedRelease.publishedAt,
+                            previousLatestPublishedAt = app.latestReleasePublishedAt,
+                            previousWasUpdateAvailable = app.isUpdateAvailable,
+                            previousLatestTag = app.latestVersion,
+                        )
                     !reconcilable -> false
                     else ->
                         VersionMath.isVersionNewer(
@@ -406,14 +411,6 @@ class InstalledAppsRepositoryImpl(
         }
 
         return false
-    }
-
-    private fun isNewerByTimestamp(
-        release: GithubRelease,
-        previousPublishedAt: String?,
-    ): Boolean {
-        val previous = previousPublishedAt ?: return false
-        return release.publishedAt > previous
     }
 
     override suspend fun checkAllForUpdates() {

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
@@ -344,8 +344,9 @@ class InstalledAppsRepositoryImpl(
                 when {
                     codesAlreadyMatch -> false
                     matchesSkipped -> false
-                    opaquePair -> isNewerByTimestamp(matchedRelease, app.latestReleasePublishedAt)
-                    sameTag && !reconcilable -> isNewerByTimestamp(matchedRelease, app.latestReleasePublishedAt)
+                    opaquePair || (sameTag && !reconcilable) ->
+                        isNewerByTimestamp(matchedRelease, app.latestReleasePublishedAt) ||
+                            (app.isUpdateAvailable && app.latestVersion == matchedRelease.tagName)
                     !reconcilable -> false
                     else ->
                         VersionMath.isVersionNewer(
@@ -380,7 +381,7 @@ class InstalledAppsRepositoryImpl(
                 latestReleasePublishedAt = matchedRelease.publishedAt,
             )
 
-            if ((codesAlreadyMatch || (!reconcilable && !sameTag && !isUpdateAvailable)) &&
+            if ((codesAlreadyMatch || (!reconcilable && !opaquePair && !sameTag && !isUpdateAvailable)) &&
                 app.installedVersion != matchedRelease.tagName
             ) {
                 installedAppsDao.updateInstalledVersion(

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
@@ -336,10 +336,16 @@ class InstalledAppsRepositoryImpl(
 
             val reconcilable =
                 VersionMath.versionsReconcilable(app.installedVersion, matchedRelease.tagName)
+            val opaquePair =
+                VersionMath.isOpaqueMarkerPair(app.installedVersion, matchedRelease.tagName)
+            val sameTag =
+                VersionMath.isExactSameVersion(matchedRelease.tagName, app.installedVersion)
             val isUpdateAvailable =
                 when {
                     codesAlreadyMatch -> false
                     matchesSkipped -> false
+                    opaquePair -> isNewerByTimestamp(matchedRelease, app.latestReleasePublishedAt)
+                    sameTag && !reconcilable -> isNewerByTimestamp(matchedRelease, app.latestReleasePublishedAt)
                     !reconcilable -> false
                     else ->
                         VersionMath.isVersionNewer(
@@ -374,7 +380,7 @@ class InstalledAppsRepositoryImpl(
                 latestReleasePublishedAt = matchedRelease.publishedAt,
             )
 
-            if ((codesAlreadyMatch || !reconcilable) &&
+            if ((codesAlreadyMatch || (!reconcilable && !sameTag && !isUpdateAvailable)) &&
                 app.installedVersion != matchedRelease.tagName
             ) {
                 installedAppsDao.updateInstalledVersion(
@@ -399,6 +405,14 @@ class InstalledAppsRepositoryImpl(
         }
 
         return false
+    }
+
+    private fun isNewerByTimestamp(
+        release: GithubRelease,
+        previousPublishedAt: String?,
+    ): Boolean {
+        val previous = previousPublishedAt ?: return false
+        return release.publishedAt > previous
     }
 
     override suspend fun checkAllForUpdates() {

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/utils/VersionMath.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/utils/VersionMath.kt
@@ -15,6 +15,7 @@ object VersionMath {
         if (parseSemanticVersion(deflavoured) != null) {
             return deflavoured
         }
+        if (isMarkerWithOpaqueSuffix(deflavoured)) return deflavoured
         val match = DOTTED_DIGIT_PATTERN.find(deflavoured)
         return match?.value ?: deflavoured
     }
@@ -59,6 +60,16 @@ object VersionMath {
         }
         if (M_DIGIT_TAIL_PATTERN.containsMatchIn(token)) return false
         return BUILD_VARIANT_LITERALS.contains(token)
+    }
+
+    private fun isMarkerWithOpaqueSuffix(version: String): Boolean {
+        val lower = version.lowercase()
+        val marker = KNOWN_PRE_RELEASE_PREFIXES.firstOrNull { lower.startsWith(it) } ?: return false
+        val rest = lower.substring(marker.length)
+        if (rest.isEmpty()) return true
+        if (rest.first() != '-' && rest.first() != '.') return false
+        val suffix = rest.substring(1)
+        return suffix.isNotEmpty() && !suffix.all { it.isDigit() }
     }
 
     private val BUILD_VARIANT_LITERALS =
@@ -109,6 +120,10 @@ object VersionMath {
         val bHash = b.preRelease?.let { isCommitHashPreRelease(it) } == true
         return aHash == bHash
     }
+
+    fun isOpaqueMarkerPair(a: String?, b: String?): Boolean =
+        isMarkerWithOpaqueSuffix(normalizeVersion(a)) &&
+            isMarkerWithOpaqueSuffix(normalizeVersion(b))
 
     private fun isCommitHashPreRelease(preRelease: String): Boolean =
         COMMIT_HASH_PATTERN.matches(preRelease)

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/utils/VersionMath.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/utils/VersionMath.kt
@@ -269,6 +269,7 @@ object VersionMath {
             "snapshot",
             "canary",
             "nightly",
+            "rolling",
             "milestone",
             "ea",
             "dev",
@@ -296,6 +297,7 @@ object VersionMath {
             raw == "snapshot" -> "Snapshot"
             raw == "canary" -> "Canary"
             raw == "nightly" -> "Nightly"
+            raw == "rolling" -> "Rolling"
             raw == "milestone" || raw.startsWith("m") -> "Milestone"
             raw == "ea" -> "Early Access"
             raw == "dev" -> "Dev"
@@ -307,7 +309,7 @@ object VersionMath {
     private val PRE_RELEASE_MARKER_PATTERN =
 
         Regex(
-            "\\b(alpha|beta|rc|preview|prerelease|snapshot|canary|nightly|milestone|ea|dev|pre|m\\d+)\\d*\\b",
+            "\\b(alpha|beta|rc|preview|prerelease|snapshot|canary|nightly|rolling|milestone|ea|dev|pre|m\\d+)\\d*\\b",
             RegexOption.IGNORE_CASE,
         )
 

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/utils/VersionMath.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/utils/VersionMath.kt
@@ -125,6 +125,27 @@ object VersionMath {
         isMarkerWithOpaqueSuffix(normalizeVersion(a)) &&
             isMarkerWithOpaqueSuffix(normalizeVersion(b))
 
+    // Whether a timestamp-tracked update (opaque markers or an unreconcilable reused
+    // tag) should still be reported as available on this scan. An update detected on a
+    // previous scan must stay surfaced until the user actually installs it: once the
+    // stored baseline timestamp equals the matched release, a pure timestamp comparison
+    // returns false, so we also retain the prior "available" flag while the matched tag
+    // still equals the stored latest tag.
+    fun shouldReportTimestampUpdate(
+        matchedTag: String?,
+        matchedPublishedAt: String?,
+        previousLatestPublishedAt: String?,
+        previousWasUpdateAvailable: Boolean,
+        previousLatestTag: String?,
+    ): Boolean {
+        val newerByTimestamp =
+            previousLatestPublishedAt != null &&
+                matchedPublishedAt != null &&
+                matchedPublishedAt > previousLatestPublishedAt
+        return newerByTimestamp ||
+            (previousWasUpdateAvailable && isExactSameVersion(matchedTag, previousLatestTag))
+    }
+
     private fun isCommitHashPreRelease(preRelease: String): Boolean =
         COMMIT_HASH_PATTERN.matches(preRelease)
 

--- a/core/domain/src/commonTest/kotlin/zed/rainxch/core/domain/utils/VersionMathTest.kt
+++ b/core/domain/src/commonTest/kotlin/zed/rainxch/core/domain/utils/VersionMathTest.kt
@@ -98,4 +98,56 @@ class VersionMathTest {
         assertEquals(VersionMath.Scheme.SemVer, VersionMath.detectScheme("v1.2.3-nightly"))
         assertEquals(VersionMath.Scheme.CalVer, VersionMath.detectScheme("2026-07-31"))
     }
+
+    @Test
+    fun timestamp_update_retained_across_scans_without_install() {
+        // Regression: an opaque-marker (nightly) update detected on one scan must stay
+        // surfaced on the next scan if the user has not installed it yet.
+        //
+        // Scan 1 detects nightly-abc -> nightly-def (publishedAt T1) and stores
+        // latestVersion=nightly-def, latestReleasePublishedAt=T1, isUpdateAvailable=true.
+        //
+        // Scan 2, no install in between: the matched release is still nightly-def (T1),
+        // so the timestamp baseline no longer advances (T1 is not > T1). Without the
+        // retention rule the update would silently disappear.
+        val stillAvailable =
+            VersionMath.shouldReportTimestampUpdate(
+                matchedTag = "nightly-def",
+                matchedPublishedAt = "2026-08-01T00:00:00Z",
+                previousLatestPublishedAt = "2026-08-01T00:00:00Z",
+                previousWasUpdateAvailable = true,
+                previousLatestTag = "nightly-def",
+            )
+        assertTrue(stillAvailable)
+    }
+
+    @Test
+    fun timestamp_update_reports_newer_release() {
+        // A genuinely newer opaque release (later publishedAt) is reported even when the
+        // previous scan had not flagged an update yet.
+        assertTrue(
+            VersionMath.shouldReportTimestampUpdate(
+                matchedTag = "nightly-def",
+                matchedPublishedAt = "2026-08-02T00:00:00Z",
+                previousLatestPublishedAt = "2026-08-01T00:00:00Z",
+                previousWasUpdateAvailable = false,
+                previousLatestTag = "nightly-abc",
+            ),
+        )
+    }
+
+    @Test
+    fun timestamp_update_not_reported_after_install() {
+        // Once the user installs (isUpdateAvailable cleared) and the baseline matches the
+        // matched release, no stale update is reported.
+        assertFalse(
+            VersionMath.shouldReportTimestampUpdate(
+                matchedTag = "nightly-def",
+                matchedPublishedAt = "2026-08-01T00:00:00Z",
+                previousLatestPublishedAt = "2026-08-01T00:00:00Z",
+                previousWasUpdateAvailable = false,
+                previousLatestTag = "nightly-def",
+            ),
+        )
+    }
 }

--- a/core/domain/src/commonTest/kotlin/zed/rainxch/core/domain/utils/VersionMathTest.kt
+++ b/core/domain/src/commonTest/kotlin/zed/rainxch/core/domain/utils/VersionMathTest.kt
@@ -1,0 +1,101 @@
+package zed.rainxch.core.domain.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class VersionMathTest {
+
+    @Test
+    fun normalize_preserves_opaque_marker_tags() {
+        assertEquals("nightly-a1b2c3d", VersionMath.normalizeVersion("nightly-a1b2c3d"))
+        assertEquals("canary-deadbeef", VersionMath.normalizeVersion("canary-deadbeef"))
+        assertEquals("nightly-abc123", VersionMath.normalizeVersion("vnightly-abc123"))
+        assertEquals("nightly", VersionMath.normalizeVersion("nightly"))
+        assertEquals("beta-x7z92", VersionMath.normalizeVersion("beta-x7z92"))
+    }
+
+    @Test
+    fun normalize_extracts_digits_from_calver_nightly() {
+        assertEquals("20260731", VersionMath.normalizeVersion("nightly-20260731"))
+        assertEquals("20260801", VersionMath.normalizeVersion("nightly-20260801"))
+    }
+
+    @Test
+    fun normalize_semver_unaffected() {
+        assertEquals("1.2.3", VersionMath.normalizeVersion("1.2.3"))
+        assertEquals("1.2.3-beta", VersionMath.normalizeVersion("v1.2.3-beta"))
+        assertEquals("2.0.9.1", VersionMath.normalizeVersion("2.0.9.1"))
+    }
+
+    @Test
+    fun opaque_marker_pair_detects_hash_suffixes() {
+        assertTrue(VersionMath.isOpaqueMarkerPair("nightly-abc", "nightly-def"))
+        assertTrue(VersionMath.isOpaqueMarkerPair("nightly", "nightly"))
+        assertTrue(VersionMath.isOpaqueMarkerPair("canary-deadbeef", "canary-cafef00d"))
+    }
+
+    @Test
+    fun opaque_marker_pair_rejects_numeric_suffixes() {
+        assertFalse(VersionMath.isOpaqueMarkerPair("nightly-abc", "nightly-20260731"))
+        assertFalse(VersionMath.isOpaqueMarkerPair("nightly-20260731", "nightly-20260801"))
+    }
+
+    @Test
+    fun opaque_marker_pair_rejects_semver() {
+        assertFalse(VersionMath.isOpaqueMarkerPair("nightly-abc", "1.2.3"))
+        assertFalse(VersionMath.isOpaqueMarkerPair("1.2.3", "1.2.4"))
+        assertFalse(VersionMath.isOpaqueMarkerPair("1.2.3-beta", "1.2.3-rc1"))
+    }
+
+    @Test
+    fun versions_reconcilable_semver() {
+        assertTrue(VersionMath.versionsReconcilable("1.2.3", "1.2.4"))
+        assertTrue(VersionMath.versionsReconcilable("v1.2.3", "1.2.3"))
+    }
+
+    @Test
+    fun versions_reconcilable_rejects_hash_mismatch() {
+        assertFalse(VersionMath.versionsReconcilable("2.0.9.1", "2.0.9-1c19925b5"))
+        assertFalse(VersionMath.versionsReconcilable("nightly-abc", "1.2.3"))
+    }
+
+    @Test
+    fun calver_nightly_compares_numerically() {
+        assertTrue(VersionMath.isVersionNewer("nightly-20260801", "nightly-20260731"))
+        assertFalse(VersionMath.isVersionNewer("nightly-20260731", "nightly-20260801"))
+    }
+
+    @Test
+    fun semver_comparison_regression() {
+        assertTrue(VersionMath.isVersionNewer("1.2.4", "1.2.3"))
+        assertFalse(VersionMath.isVersionNewer("1.2.3", "1.2.4"))
+        assertTrue(VersionMath.isVersionNewer("2.0.0", "1.9.9"))
+        assertFalse(VersionMath.isVersionNewer("1.0.0-alpha", "1.0.0"))
+    }
+
+    @Test
+    fun nightly_is_prerelease_tag() {
+        assertTrue(VersionMath.isPreReleaseTag("nightly"))
+        assertTrue(VersionMath.isPreReleaseTag("nightly-abc"))
+        assertTrue(VersionMath.isPreReleaseTag("nightly-20260731"))
+        assertFalse(VersionMath.isPreReleaseTag("v1.2.3"))
+        assertFalse(VersionMath.isPreReleaseTag("1.2.3"))
+    }
+
+    @Test
+    fun nightly_marker_label() {
+        assertEquals("Nightly", VersionMath.preReleaseMarkerLabel("nightly"))
+        assertEquals("Nightly", VersionMath.preReleaseMarkerLabel("nightly-abc"))
+        assertEquals("Nightly", VersionMath.preReleaseMarkerLabel("v1.2.3-nightly"))
+    }
+
+    @Test
+    fun detect_scheme_for_nightly() {
+        assertEquals(VersionMath.Scheme.Unknown, VersionMath.detectScheme("nightly"))
+        assertEquals(VersionMath.Scheme.Unknown, VersionMath.detectScheme("nightly-abc"))
+        assertEquals(VersionMath.Scheme.SemVer, VersionMath.detectScheme("v1.2.3-nightly"))
+        assertEquals(VersionMath.Scheme.CalVer, VersionMath.detectScheme("2026-07-31"))
+    }
+}

--- a/core/domain/src/commonTest/kotlin/zed/rainxch/core/domain/utils/VersionMathTest.kt
+++ b/core/domain/src/commonTest/kotlin/zed/rainxch/core/domain/utils/VersionMathTest.kt
@@ -14,12 +14,15 @@ class VersionMathTest {
         assertEquals("nightly-abc123", VersionMath.normalizeVersion("vnightly-abc123"))
         assertEquals("nightly", VersionMath.normalizeVersion("nightly"))
         assertEquals("beta-x7z92", VersionMath.normalizeVersion("beta-x7z92"))
+        assertEquals("rolling-abc123", VersionMath.normalizeVersion("rolling-abc123"))
+        assertEquals("rolling", VersionMath.normalizeVersion("rolling"))
     }
 
     @Test
     fun normalize_extracts_digits_from_calver_nightly() {
         assertEquals("20260731", VersionMath.normalizeVersion("nightly-20260731"))
         assertEquals("20260801", VersionMath.normalizeVersion("nightly-20260801"))
+        assertEquals("20260801", VersionMath.normalizeVersion("rolling-20260801"))
     }
 
     @Test
@@ -34,6 +37,7 @@ class VersionMathTest {
         assertTrue(VersionMath.isOpaqueMarkerPair("nightly-abc", "nightly-def"))
         assertTrue(VersionMath.isOpaqueMarkerPair("nightly", "nightly"))
         assertTrue(VersionMath.isOpaqueMarkerPair("canary-deadbeef", "canary-cafef00d"))
+        assertTrue(VersionMath.isOpaqueMarkerPair("rolling-a", "rolling-b"))
     }
 
     @Test
@@ -80,6 +84,8 @@ class VersionMathTest {
         assertTrue(VersionMath.isPreReleaseTag("nightly"))
         assertTrue(VersionMath.isPreReleaseTag("nightly-abc"))
         assertTrue(VersionMath.isPreReleaseTag("nightly-20260731"))
+        assertTrue(VersionMath.isPreReleaseTag("rolling"))
+        assertTrue(VersionMath.isPreReleaseTag("rolling-abc"))
         assertFalse(VersionMath.isPreReleaseTag("v1.2.3"))
         assertFalse(VersionMath.isPreReleaseTag("1.2.3"))
     }
@@ -89,6 +95,8 @@ class VersionMathTest {
         assertEquals("Nightly", VersionMath.preReleaseMarkerLabel("nightly"))
         assertEquals("Nightly", VersionMath.preReleaseMarkerLabel("nightly-abc"))
         assertEquals("Nightly", VersionMath.preReleaseMarkerLabel("v1.2.3-nightly"))
+        assertEquals("Rolling", VersionMath.preReleaseMarkerLabel("rolling"))
+        assertEquals("Rolling", VersionMath.preReleaseMarkerLabel("rolling-abc"))
     }
 
     @Test


### PR DESCRIPTION
Nightly and rolling releases use auto-generated tags (nightly-a1b2c3d, nightly-20260731, or bare nightly) that break version comparison:

1. normalizeVersion extracted meaningless digits from hash suffixes (nightly-a1b2c3d -> 1), making comparisons unreliable.
2. versionsReconcilable returned false when both tags were unparseable as semver, silently suppressing all nightly updates.
3. Reused tags (bare nightly) compared as equal, so re-published nightlies never triggered update detection.

Fix:
- normalizeVersion preserves marker+opaque-suffix tags intact instead of running the digit extractor over them.
- isOpaqueMarkerPair lets callers identify pairs like nightly-abc vs nightly-def that should fall back to timestamp comparison.
- checkForUpdates uses publishedAt timestamps for opaque-marker pairs and for same-tag re-publishes where semver comparison is impossible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update detection for apps using unusual or opaque version tags.
  * More accurately identifies updates by comparing release publication dates when version tags cannot be directly reconciled.
  * Prevented unnecessary installed-version synchronization when no valid update is available.
  * Improved handling of pre-release, nightly, rolling, calendar-based, and semantic version formats.
* **Tests**
  * Expanded coverage for version normalization, comparison, ordering, and update detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->