### PR TITLE
fix(ui): consume bottom window insets to prevent double padding above…

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
@@ -9,7 +9,9 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -152,9 +154,12 @@ fun AppNavigation(
 
                     SharedTransitionLayout(
                         modifier =
-                            Modifier.padding(
-                                bottom = if (showBottomBar) bottomBarHeight else 0.dp,
-                            ),
+                            Modifier
+                                .padding(
+                                    bottom = if (showBottomBar) bottomBarHeight else 0.dp,
+                                ).then(
+                                    if (showBottomBar) Modifier.consumeWindowInsets(PaddingValues(bottom = bottomBarHeight)) else Modifier,
+                                ),
                     ) {
                         NavHost(
                             navController = navController,

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -1497,6 +1497,8 @@
     <string name="feed_offline">Offline — showing a saved feed</string>
     <string name="feed_failed_to_load">Couldn\'t load the feed</string>
     <string name="feed_end_cap">続く · TO BE CONTINUED</string>
+    <string name="feed_layout_description_grid">Switch to grid layout</string>
+    <string name="feed_layout_description_list">Switch to list layout</string>
     <string name="feed_category_ai">AI</string>
     <string name="feed_category_privacy">Privacy</string>
     <string name="feed_category_networking">Networking</string>

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/buttons/KomiButton.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/buttons/KomiButton.kt
@@ -375,7 +375,7 @@ private data class ButtonMetrics(
 
 private fun buttonMetrics(size: KomiButtonSize): ButtonMetrics =
     when (size) {
-        KomiButtonSize.Sm -> ButtonMetrics(34.dp, 14.dp, 12.sp, 15.dp, 7.dp, 3.dp, 2.5.dp)
+        KomiButtonSize.Sm -> ButtonMetrics(34.dp, 14.dp, 12.sp, 15.dp, 7.dp, 3.dp, 1.5.dp)
         KomiButtonSize.Md -> ButtonMetrics(44.dp, 20.dp, 13.5.sp, 18.dp, 9.dp, 4.dp, 2.5.dp)
         KomiButtonSize.Lg -> ButtonMetrics(54.dp, 26.dp, 16.sp, 22.dp, 10.dp, 5.dp, 3.dp)
     }

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/buttons/KomiIconButton.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/buttons/KomiIconButton.kt
@@ -191,6 +191,7 @@ private fun ClassicIconButton(
 ) {
     val colors = LocalPersonality.current.colors
     val metrics = size.metrics
+    val sizeModifier = Modifier.size(metrics.box)
     val content: @Composable () -> Unit = {
         Icon(
             imageVector = icon,
@@ -203,7 +204,7 @@ private fun ClassicIconButton(
         KomiButtonVariant.Primary -> {
             FilledIconButton(
                 onClick = onClick,
-                modifier = modifier,
+                modifier = modifier.then(sizeModifier),
                 enabled = enabled,
                 content = content,
             )
@@ -212,7 +213,7 @@ private fun ClassicIconButton(
         KomiButtonVariant.Tonal -> {
             FilledTonalIconButton(
                 onClick = onClick,
-                modifier = modifier,
+                modifier = modifier.then(sizeModifier),
                 enabled = enabled,
                 content = content,
             )
@@ -221,7 +222,7 @@ private fun ClassicIconButton(
         KomiButtonVariant.Outline -> {
             OutlinedIconButton(
                 onClick = onClick,
-                modifier = modifier,
+                modifier = modifier.then(sizeModifier),
                 enabled = enabled,
                 content = content,
             )
@@ -230,7 +231,7 @@ private fun ClassicIconButton(
         KomiButtonVariant.Text -> {
             IconButton(
                 onClick = onClick,
-                modifier = modifier,
+                modifier = modifier.then(sizeModifier),
                 enabled = enabled,
                 content = content,
             )
@@ -239,7 +240,7 @@ private fun ClassicIconButton(
         KomiButtonVariant.Destructive -> {
             FilledIconButton(
                 onClick = onClick,
-                modifier = modifier,
+                modifier = modifier.then(sizeModifier),
                 enabled = enabled,
                 colors =
                     IconButtonDefaults.filledIconButtonColors(

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/buttons/KomiIconButton.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/buttons/KomiIconButton.kt
@@ -53,6 +53,18 @@ import kotlin.math.roundToInt
 
 private val MinTouchTarget = 44.dp
 
+/**
+ * A highly customizable icon button component supporting multiple sizes, variants,
+ * and visual personalities (e.g., Manga or Classic themes).
+ *
+ * @param icon The vector asset to display as the icon content.
+ * @param contentDescription Description for accessibility screen readers.
+ * @param onClick Lambda callback executed when the button is clicked.
+ * @param modifier Optional Compose [Modifier] to configure layout behavior.
+ * @param variant Visual button variant (Tonal, Primary, Outline, Text, or Destructive).
+ * @param size Layout size variant of the button (Sm, Md, or Lg).
+ * @param enabled Whether the button responds to click interactions.
+ */
 @Composable
 fun KomiIconButton(
     icon: ImageVector,
@@ -191,7 +203,7 @@ private fun ClassicIconButton(
 ) {
     val colors = LocalPersonality.current.colors
     val metrics = size.metrics
-    val sizeModifier = Modifier.size(metrics.box)
+    val sizeModifier = Modifier.size(maxOf(metrics.box, MinTouchTarget))
     val content: @Composable () -> Unit = {
         Icon(
             imageVector = icon,

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/buttons/KomiIconButtonSize.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/buttons/KomiIconButtonSize.kt
@@ -2,12 +2,21 @@ package zed.rainxch.core.presentation.components.buttons
 
 import androidx.compose.ui.unit.dp
 
+/**
+ * Defines the size configurations for icon buttons.
+ */
 enum class KomiIconButtonSize {
+    /** Small size (e.g., 34.dp box). */
     Sm,
+    /** Medium size (e.g., 42.dp box). */
     Md,
+    /** Large size (e.g., 48.dp box). */
     Lg,
 }
 
+/**
+ * Returns the layout/border/shadow metrics corresponding to this icon button size.
+ */
 val KomiIconButtonSize.metrics: KomiIconButtonMetrics
     get() =
         when (this) {

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/buttons/KomiIconButtonSize.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/buttons/KomiIconButtonSize.kt
@@ -11,7 +11,7 @@ enum class KomiIconButtonSize {
 val KomiIconButtonSize.metrics: KomiIconButtonMetrics
     get() =
         when (this) {
-            KomiIconButtonSize.Sm -> KomiIconButtonMetrics(box = 34.dp, icon = 18.dp, shadow = 3.dp, border = 2.5.dp)
+            KomiIconButtonSize.Sm -> KomiIconButtonMetrics(box = 34.dp, icon = 18.dp, shadow = 3.dp, border = 1.5.dp)
             KomiIconButtonSize.Md -> KomiIconButtonMetrics(box = 42.dp, icon = 20.dp, shadow = 4.dp, border = 2.5.dp)
             KomiIconButtonSize.Lg -> KomiIconButtonMetrics(box = 48.dp, icon = 22.dp, shadow = 4.dp, border = 2.5.dp)
         }

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/cards/KomiRepoCard.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/cards/KomiRepoCard.kt
@@ -175,29 +175,31 @@ fun KomiRepoCard(
                 modifier = Modifier.padding(top = gap),
             )
 
-            FlowRow(
-                modifier = Modifier.padding(top = gap),
-                horizontalArrangement = Arrangement.spacedBy(7.dp),
-                verticalArrangement = Arrangement.spacedBy(7.dp),
-            ) {
-                platforms.forEach { platform ->
-                    KomiChip(
-                        label = platform.toLabel(),
-                        kind = KomiChipKind.Info,
-                        size = if (compact) KomiChipSize.Sm else KomiChipSize.Md,
-                        leadingContent = {
-                            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                                platform.toIcon()?.let { icon ->
-                                    Icon(
-                                        imageVector = icon,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(14.dp),
-                                        tint = colors.onSurface,
-                                    )
+            if (!compact && platforms.isNotEmpty()) {
+                FlowRow(
+                    modifier = Modifier.padding(top = gap),
+                    horizontalArrangement = Arrangement.spacedBy(7.dp),
+                    verticalArrangement = Arrangement.spacedBy(7.dp),
+                ) {
+                    platforms.forEach { platform ->
+                        KomiChip(
+                            label = platform.toLabel(),
+                            kind = KomiChipKind.Info,
+                            size = if (compact) KomiChipSize.Sm else KomiChipSize.Md,
+                            leadingContent = {
+                                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                    platform.toIcon()?.let { icon ->
+                                        Icon(
+                                            imageVector = icon,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(14.dp),
+                                            tint = colors.onSurface,
+                                        )
+                                    }
                                 }
-                            }
-                        },
-                    )
+                            },
+                        )
+                    }
                 }
             }
 
@@ -212,8 +214,9 @@ fun KomiRepoCard(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(13.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    horizontalArrangement = Arrangement.spacedBy(if (compact) 8.dp else 13.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.weight(1f, fill = false)
                 ) {
                     Stat(
                         icon = Icons.Filled.Star,
@@ -226,21 +229,26 @@ fun KomiRepoCard(
                         value = fmtCompact(downloads),
                         colors = colors
                     )
-                    formatReleasedAgo(releasedAt)?.let { ago ->
-                        Stat(
-                            icon = Icons.Outlined.Schedule,
-                            value = ago,
-                            colors = colors
-                        )
+                    if (!compact) {
+                        formatReleasedAgo(releasedAt)?.let { ago ->
+                            Stat(
+                                icon = Icons.Outlined.Schedule,
+                                value = ago,
+                                colors = colors
+                            )
+                        }
                     }
                 }
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    KomiText(
-                        text = "Read",
-                        role = KomiTextRole.Label,
-                        color = colors.onSurface,
-                        fontSize = 12.5.sp
-                    )
+                    if (!compact) {
+                        KomiText(
+                            text = "Read",
+                            role = KomiTextRole.Label,
+                            color = colors.onSurface,
+                            fontSize = 12.5.sp,
+                            modifier = Modifier.padding(end = 2.dp)
+                        )
+                    }
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                         contentDescription = null,

--- a/feature/feed/presentation/src/commonMain/kotlin/zed/rainxch/feed/presentation/FeedAction.kt
+++ b/feature/feed/presentation/src/commonMain/kotlin/zed/rainxch/feed/presentation/FeedAction.kt
@@ -20,4 +20,5 @@ sealed interface FeedAction {
     data class OnHideRepository(val repo: GithubRepoSummaryUi) : FeedAction
     data class OnMarkAsSeen(val repo: GithubRepoSummaryUi) : FeedAction
     data class OnMarkAsUnseen(val repoId: Long) : FeedAction
+    data object OnToggleLayoutType : FeedAction
 }

--- a/feature/feed/presentation/src/commonMain/kotlin/zed/rainxch/feed/presentation/FeedAction.kt
+++ b/feature/feed/presentation/src/commonMain/kotlin/zed/rainxch/feed/presentation/FeedAction.kt
@@ -4,21 +4,40 @@ import zed.rainxch.core.domain.model.repository.DiscoveryPlatform
 import zed.rainxch.core.presentation.model.GithubRepoSummaryUi
 import zed.rainxch.core.domain.model.repository.FeedCategory
 
+/**
+ * Represents actions/events triggered by the user on the feed screen.
+ */
 sealed interface FeedAction {
+    /** Triggered on swipe-to-refresh. */
     data object OnRefresh : FeedAction
+    /** Triggered to retry loading the feed after an error. */
     data object OnRetry : FeedAction
+    /** Triggered when scrolling close to the bottom to load the next page. */
     data object OnLoadMore : FeedAction
+    /** Triggered when the search button is clicked. */
     data object OnSearchClick : FeedAction
+    /** Triggered when the user profile button is clicked. */
     data object OnProfileClick : FeedAction
+    /** Triggered to open the platform picker. */
     data object OnPlatformPickerOpen : FeedAction
+    /** Triggered to close the platform picker. */
     data object OnPlatformPickerDismiss : FeedAction
+    /** Triggered to clear all filters. */
     data object OnResetFilters : FeedAction
+    /** Triggered when a platform is selected. */
     data class OnPlatformSelected(val platform: DiscoveryPlatform) : FeedAction
+    /** Triggered when a category is selected. */
     data class OnCategorySelected(val category: FeedCategory) : FeedAction
+    /** Triggered when a repository card is clicked. */
     data class OnRepoClick(val repo: GithubRepoSummaryUi) : FeedAction
+    /** Triggered when a repository is shared. */
     data class OnShareClick(val repo: GithubRepoSummaryUi) : FeedAction
+    /** Triggered when a repository is hidden. */
     data class OnHideRepository(val repo: GithubRepoSummaryUi) : FeedAction
+    /** Triggered when marking a repository as seen. */
     data class OnMarkAsSeen(val repo: GithubRepoSummaryUi) : FeedAction
+    /** Triggered when removing a repository from the seen history. */
     data class OnMarkAsUnseen(val repoId: Long) : FeedAction
+    /** Triggered when toggling layout presentation between list and grid. */
     data object OnToggleLayoutType : FeedAction
 }

--- a/feature/feed/presentation/src/commonMain/kotlin/zed/rainxch/feed/presentation/FeedRoot.kt
+++ b/feature/feed/presentation/src/commonMain/kotlin/zed/rainxch/feed/presentation/FeedRoot.kt
@@ -37,9 +37,19 @@ import zed.rainxch.core.domain.model.repository.FeedCategory
 import zed.rainxch.core.presentation.components.bars.KomiTopBar
 import zed.rainxch.core.presentation.components.buttons.KomiButton
 import zed.rainxch.core.presentation.components.buttons.KomiButtonVariant
+import zed.rainxch.core.presentation.components.buttons.KomiIconButton
+import zed.rainxch.core.presentation.components.buttons.KomiIconButtonSize
 import zed.rainxch.core.presentation.components.cards.DiscoveryRepoCard
 import zed.rainxch.core.presentation.components.cards.KomiRepoCardFeed
 import zed.rainxch.core.presentation.components.dividers.KomiHorizontalDivider
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.automirrored.filled.ViewList
 import zed.rainxch.core.presentation.components.overlays.KomiToastState
 import zed.rainxch.core.presentation.components.overlays.rememberKomiToastState
 import zed.rainxch.core.presentation.components.progress.KomiCircularProgress
@@ -53,11 +63,16 @@ import zed.rainxch.core.presentation.personality.usesDecor
 import zed.rainxch.core.presentation.utils.ObserveAsEvents
 import zed.rainxch.core.presentation.utils.constrainedContentWidth
 import zed.rainxch.core.presentation.utils.toLabel
+import zed.rainxch.core.presentation.utils.toIcon
+import zed.rainxch.core.presentation.components.buttons.KomiButtonSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.KeyboardArrowDown
 import zed.rainxch.feed.presentation.components.FeedCategoryStrip
 import zed.rainxch.feed.presentation.components.FeedPlatformBar
 import zed.rainxch.feed.presentation.components.FeedPlatformPicker
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.feed_empty_reset
+import zed.rainxch.githubstore.core.presentation.res.feed_platform_all
 import zed.rainxch.githubstore.core.presentation.res.feed_empty_subtitle
 import zed.rainxch.githubstore.core.presentation.res.feed_empty_title
 import zed.rainxch.githubstore.core.presentation.res.feed_end_cap
@@ -79,12 +94,19 @@ fun FeedRoot(
     val state by viewModel.state.collectAsStateWithLifecycle()
     val toastState = rememberKomiToastState()
     val listState = rememberLazyListState()
+    val gridState = rememberLazyGridState()
     val coroutineScope = rememberCoroutineScope()
 
     ObserveAsEvents(viewModel.events) { event ->
         when (event) {
             is FeedEvent.OnMessage -> toastState.show(event.message)
-            FeedEvent.OnScrollToTop -> coroutineScope.launch { listState.scrollToItem(0) }
+            FeedEvent.OnScrollToTop -> coroutineScope.launch {
+                if (state.layoutType == FeedLayoutType.LIST) {
+                    listState.scrollToItem(0)
+                } else {
+                    gridState.scrollToItem(0)
+                }
+            }
         }
     }
 
@@ -92,6 +114,7 @@ fun FeedRoot(
         state = state,
         toastState = toastState,
         listState = listState,
+        gridState = gridState,
         onAction = { action ->
             when (action) {
                 FeedAction.OnSearchClick -> onNavigateToSearch()
@@ -109,13 +132,20 @@ private fun FeedScreen(
     state: FeedState,
     toastState: KomiToastState,
     listState: LazyListState,
+    gridState: LazyGridState,
     onAction: (FeedAction) -> Unit,
 ) {
-    val reachedEnd by remember {
+    val reachedEnd by remember(state.layoutType) {
         derivedStateOf {
-            val info = listState.layoutInfo
-            val lastIndex = info.visibleItemsInfo.lastOrNull()?.index ?: -1
-            lastIndex >= info.totalItemsCount - 4
+            if (state.layoutType == FeedLayoutType.LIST) {
+                val info = listState.layoutInfo
+                val lastIndex = info.visibleItemsInfo.lastOrNull()?.index ?: -1
+                lastIndex >= info.totalItemsCount - 4
+            } else {
+                val info = gridState.layoutInfo
+                val lastIndex = info.visibleItemsInfo.lastOrNull()?.index ?: -1
+                lastIndex >= info.totalItemsCount - 6
+            }
         }
     }
 
@@ -131,6 +161,27 @@ private fun FeedScreen(
                 title = stringResource(Res.string.feed_masthead_title),
                 titleAccent = stringResource(Res.string.feed_masthead_title_accent),
                 subtitle = if (LocalPersonality.current.usesDecor) stringResource(Res.string.feed_masthead_subtitle) else null,
+                actions = {
+                    KomiIconButton(
+                        icon = if (state.layoutType == FeedLayoutType.LIST) Icons.Default.GridView else Icons.AutoMirrored.Filled.ViewList,
+                        contentDescription = "Toggle Layout",
+                        onClick = { onAction(FeedAction.OnToggleLayoutType) },
+                        variant = KomiButtonVariant.Primary,
+                        size = KomiIconButtonSize.Sm,
+                        modifier = Modifier.padding(end = 8.dp),
+                    )
+
+                    val platform = state.selectedPlatform
+                    KomiButton(
+                        onClick = { onAction(FeedAction.OnPlatformPickerOpen) },
+                        label = if (platform == DiscoveryPlatform.All) stringResource(Res.string.feed_platform_all) else platform.toLabel(),
+                        variant = KomiButtonVariant.Primary,
+                        size = KomiButtonSize.Sm,
+                        leadingIcon = if (platform == DiscoveryPlatform.All) null else platform.toIcon(),
+                        trailingIcon = Icons.Rounded.KeyboardArrowDown,
+                        modifier = Modifier.padding(end = 12.dp),
+                    )
+                }
             )
         },
         toastState = toastState,
@@ -145,6 +196,7 @@ private fun FeedScreen(
             ) {
                 FeedContent(
                     listState = listState,
+                    gridState = gridState,
                     state = state,
                     onAction = onAction,
                 )
@@ -157,6 +209,7 @@ private fun FeedScreen(
             ) {
                 FeedContent(
                     listState = listState,
+                    gridState = gridState,
                     state = state,
                     onAction = onAction,
                 )
@@ -176,109 +229,210 @@ private fun FeedScreen(
 @Composable
 private fun BoxScope.FeedContent(
     listState: LazyListState,
+    gridState: LazyGridState,
     state: FeedState,
     onAction: (FeedAction) -> Unit,
 ) {
     val colors = LocalPersonality.current.colors
     val isManga = LocalPersonality.current is MangaPersonality
 
-    LazyColumn(
-        state = listState,
-        modifier = Modifier
-            .constrainedContentWidth()
-            .fillMaxSize()
-            .align(Alignment.TopCenter),
-        contentPadding = PaddingValues(bottom = 32.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        if (!isDesktop()) {
-            stickyHeader(key = "feed_controls", contentType = "controls") {
-                Column(modifier = Modifier.fillMaxWidth().background(colors.background)) {
-                    FeedPlatformBar(
-                        platform = state.selectedPlatform,
-                        onOpenPicker = { onAction(FeedAction.OnPlatformPickerOpen) },
-                    )
+    if (state.layoutType == FeedLayoutType.LIST) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .constrainedContentWidth()
+                .fillMaxSize()
+                .align(Alignment.TopCenter),
+            contentPadding = PaddingValues(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            if (!isDesktop()) {
+                stickyHeader(key = "feed_controls", contentType = "controls") {
+                    Column(modifier = Modifier.fillMaxWidth().background(colors.background).padding(top = 6.dp)) {
+                        FeedCategoryStrip(
+                            categories = state.categories,
+                            selected = state.selectedCategory,
+                            onSelect = { onAction(FeedAction.OnCategorySelected(it)) },
+                        )
 
-                    FeedCategoryStrip(
-                        categories = state.categories,
-                        selected = state.selectedCategory,
-                        onSelect = { onAction(FeedAction.OnCategorySelected(it)) },
-                    )
+                        if (isManga) {
+                            KomiHorizontalDivider(thickness = 3.dp, color = colors.outline)
+                        }
+                    }
+                }
+            }
 
-                    if (isManga) {
-                        KomiHorizontalDivider(thickness = 3.dp, color = colors.outline)
+            when {
+                state.isLoading && state.repos.isEmpty() -> {
+                    item(key = "feed_loading") { FeedLoading() }
+                }
+
+                state.errorMessage != null && state.repos.isEmpty() -> {
+                    item(key = "feed_error") {
+                        FeedError(
+                            message = state.errorMessage,
+                            onRetry = { onAction(FeedAction.OnRetry) },
+                        )
+                    }
+                }
+
+                else -> {
+                    if (state.isOffline) {
+                        item(key = "feed_offline") {
+                            KomiText(
+                                text = stringResource(Res.string.feed_offline),
+                                role = KomiTextRole.Label,
+                                color = colors.onSurfaceVariant,
+                                modifier = Modifier.fillMaxWidth()
+                                    .padding(horizontal = 12.dp, vertical = 2.dp),
+                            )
+                        }
+                    }
+
+                    if (state.repos.isEmpty()) {
+                        item(key = "feed_empty") {
+                            FeedEmpty(
+                                category = state.selectedCategory,
+                                platform = state.selectedPlatform,
+                                onReset = { onAction(FeedAction.OnResetFilters) },
+                            )
+                        }
+                    } else {
+                        items(state.repos, key = { "feed_${it.repository.id}" }) { card ->
+                            DiscoveryRepoCard(
+                                discoveryRepositoryUi = card,
+                                onClick = { onAction(FeedAction.OnRepoClick(card.repository)) },
+                                onShareClick = { onAction(FeedAction.OnShareClick(card.repository)) },
+                                onHideClick = { onAction(FeedAction.OnHideRepository(card.repository)) },
+                                onToggleSeen = {
+                                    if (card.isSeen) {
+                                        onAction(FeedAction.OnMarkAsUnseen(card.repository.id))
+                                    } else {
+                                        onAction(FeedAction.OnMarkAsSeen(card.repository))
+                                    }
+                                },
+                                feed = KomiRepoCardFeed.Release,
+                                modifier = Modifier.fillMaxWidth()
+                                    .padding(horizontal = 12.dp)
+                                    .animateItem(),
+                            )
+                        }
+
+                        if (state.isLoadingMore) {
+                            item(key = "feed_loading_more") {
+                                Box(
+                                    modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    KomiCircularProgress(modifier = Modifier.size(28.dp))
+                                }
+                            }
+                        } else if (!state.hasMore) {
+                            item(key = "feed_end_cap") { FeedEndCap() }
+                        }
                     }
                 }
             }
         }
-
-        when {
-            state.isLoading && state.repos.isEmpty() -> {
-                item(key = "feed_loading") { FeedLoading() }
-            }
-
-            state.errorMessage != null && state.repos.isEmpty() -> {
-                item(key = "feed_error") {
-                    FeedError(
-                        message = state.errorMessage,
-                        onRetry = { onAction(FeedAction.OnRetry) },
-                    )
-                }
-            }
-
-            else -> {
-                if (state.isOffline) {
-                    item(key = "feed_offline") {
-                        KomiText(
-                            text = stringResource(Res.string.feed_offline),
-                            role = KomiTextRole.Label,
-                            color = colors.onSurfaceVariant,
-                            modifier = Modifier.fillMaxWidth()
-                                .padding(horizontal = 12.dp, vertical = 2.dp),
+    } else {
+        LazyVerticalGrid(
+            columns = GridCells.Adaptive(minSize = 170.dp),
+            state = gridState,
+            modifier = Modifier
+                .constrainedContentWidth()
+                .fillMaxSize()
+                .align(Alignment.TopCenter),
+            contentPadding = PaddingValues(start = 12.dp, end = 12.dp, bottom = 32.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            if (!isDesktop()) {
+                item(
+                    key = "feed_controls",
+                    span = { GridItemSpan(maxLineSpan) }
+                ) {
+                    Column(modifier = Modifier.fillMaxWidth().background(colors.background).padding(top = 6.dp)) {
+                        FeedCategoryStrip(
+                            categories = state.categories,
+                            selected = state.selectedCategory,
+                            onSelect = { onAction(FeedAction.OnCategorySelected(it)) },
                         )
-                    }
-                }
 
-                if (state.repos.isEmpty()) {
-                    item(key = "feed_empty") {
-                        FeedEmpty(
-                            category = state.selectedCategory,
-                            platform = state.selectedPlatform,
-                            onReset = { onAction(FeedAction.OnResetFilters) },
-                        )
-                    }
-                } else {
-                    items(state.repos, key = { "feed_${it.repository.id}" }) { card ->
-                        DiscoveryRepoCard(
-                            discoveryRepositoryUi = card,
-                            onClick = { onAction(FeedAction.OnRepoClick(card.repository)) },
-                            onShareClick = { onAction(FeedAction.OnShareClick(card.repository)) },
-                            onHideClick = { onAction(FeedAction.OnHideRepository(card.repository)) },
-                            onToggleSeen = {
-                                if (card.isSeen) {
-                                    onAction(FeedAction.OnMarkAsUnseen(card.repository.id))
-                                } else {
-                                    onAction(FeedAction.OnMarkAsSeen(card.repository))
-                                }
-                            },
-                            feed = KomiRepoCardFeed.Release,
-                            modifier = Modifier.fillMaxWidth()
-                                .padding(horizontal = 12.dp)
-                                .animateItem(),
-                        )
-                    }
-
-                    if (state.isLoadingMore) {
-                        item(key = "feed_loading_more") {
-                            Box(
-                                modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                KomiCircularProgress(modifier = Modifier.size(28.dp))
-                            }
+                        if (isManga) {
+                            KomiHorizontalDivider(thickness = 3.dp, color = colors.outline)
                         }
-                    } else if (!state.hasMore) {
-                        item(key = "feed_end_cap") { FeedEndCap() }
+                    }
+                }
+            }
+
+            when {
+                state.isLoading && state.repos.isEmpty() -> {
+                    item(key = "feed_loading", span = { GridItemSpan(maxLineSpan) }) { FeedLoading() }
+                }
+
+                state.errorMessage != null && state.repos.isEmpty() -> {
+                    item(key = "feed_error", span = { GridItemSpan(maxLineSpan) }) {
+                        FeedError(
+                            message = state.errorMessage,
+                            onRetry = { onAction(FeedAction.OnRetry) },
+                        )
+                    }
+                }
+
+                else -> {
+                    if (state.isOffline) {
+                        item(key = "feed_offline", span = { GridItemSpan(maxLineSpan) }) {
+                            KomiText(
+                                text = stringResource(Res.string.feed_offline),
+                                role = KomiTextRole.Label,
+                                color = colors.onSurfaceVariant,
+                                modifier = Modifier.fillMaxWidth()
+                                    .padding(vertical = 2.dp),
+                            )
+                        }
+                    }
+
+                    if (state.repos.isEmpty()) {
+                        item(key = "feed_empty", span = { GridItemSpan(maxLineSpan) }) {
+                            FeedEmpty(
+                                category = state.selectedCategory,
+                                platform = state.selectedPlatform,
+                                onReset = { onAction(FeedAction.OnResetFilters) },
+                            )
+                        }
+                    } else {
+                        items(state.repos, key = { "feed_${it.repository.id}" }) { card ->
+                            DiscoveryRepoCard(
+                                discoveryRepositoryUi = card,
+                                onClick = { onAction(FeedAction.OnRepoClick(card.repository)) },
+                                onShareClick = { onAction(FeedAction.OnShareClick(card.repository)) },
+                                onHideClick = { onAction(FeedAction.OnHideRepository(card.repository)) },
+                                onToggleSeen = {
+                                    if (card.isSeen) {
+                                        onAction(FeedAction.OnMarkAsUnseen(card.repository.id))
+                                    } else {
+                                        onAction(FeedAction.OnMarkAsSeen(card.repository))
+                                    }
+                                },
+                                feed = KomiRepoCardFeed.Release,
+                                compact = true,
+                                modifier = Modifier.fillMaxWidth()
+                                    .animateItem(),
+                            )
+                        }
+
+                        if (state.isLoadingMore) {
+                            item(key = "feed_loading_more", span = { GridItemSpan(maxLineSpan) }) {
+                                Box(
+                                    modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    KomiCircularProgress(modifier = Modifier.size(28.dp))
+                                }
+                            }
+                        } else if (!state.hasMore) {
+                            item(key = "feed_end_cap", span = { GridItemSpan(maxLineSpan) }) { FeedEndCap() }
+                        }
                     }
                 }
             }

--- a/feature/feed/presentation/src/commonMain/kotlin/zed/rainxch/feed/presentation/FeedRoot.kt
+++ b/feature/feed/presentation/src/commonMain/kotlin/zed/rainxch/feed/presentation/FeedRoot.kt
@@ -77,6 +77,8 @@ import zed.rainxch.githubstore.core.presentation.res.feed_empty_subtitle
 import zed.rainxch.githubstore.core.presentation.res.feed_empty_title
 import zed.rainxch.githubstore.core.presentation.res.feed_end_cap
 import zed.rainxch.githubstore.core.presentation.res.feed_failed_to_load
+import zed.rainxch.githubstore.core.presentation.res.feed_layout_description_grid
+import zed.rainxch.githubstore.core.presentation.res.feed_layout_description_list
 import zed.rainxch.githubstore.core.presentation.res.feed_loading
 import zed.rainxch.githubstore.core.presentation.res.feed_masthead_subtitle
 import zed.rainxch.githubstore.core.presentation.res.feed_masthead_title
@@ -164,7 +166,11 @@ private fun FeedScreen(
                 actions = {
                     KomiIconButton(
                         icon = if (state.layoutType == FeedLayoutType.LIST) Icons.Default.GridView else Icons.AutoMirrored.Filled.ViewList,
-                        contentDescription = "Toggle Layout",
+                        contentDescription = if (state.layoutType == FeedLayoutType.LIST) {
+                            stringResource(Res.string.feed_layout_description_grid)
+                        } else {
+                            stringResource(Res.string.feed_layout_description_list)
+                        },
                         onClick = { onAction(FeedAction.OnToggleLayoutType) },
                         variant = KomiButtonVariant.Primary,
                         size = KomiIconButtonSize.Sm,

--- a/feature/feed/presentation/src/commonMain/kotlin/zed/rainxch/feed/presentation/FeedState.kt
+++ b/feature/feed/presentation/src/commonMain/kotlin/zed/rainxch/feed/presentation/FeedState.kt
@@ -8,11 +8,32 @@ import zed.rainxch.core.domain.model.repository.DiscoveryPlatform
 import zed.rainxch.core.presentation.model.DiscoveryRepositoryUi
 import zed.rainxch.core.domain.model.repository.FeedCategory
 
+/**
+ * Represents the available layout presentations for the feed list.
+ */
 enum class FeedLayoutType {
+    /** Renders feed repositories in a list layout. */
     LIST,
+    /** Renders feed repositories in a grid layout. */
     GRID
 }
 
+/**
+ * Represents the UI state of the feed screen.
+ *
+ * @property repos The list of repository card UI models currently displayed.
+ * @property categories The list of categories available for filtering the feed.
+ * @property selectedCategory The currently selected category filter.
+ * @property selectedPlatform The currently selected platform filter.
+ * @property isPlatformPickerVisible Whether the platform selection modal/picker is visible.
+ * @property isLoading Whether the initial loading state is active.
+ * @property isRefreshing Whether a swipe-to-refresh reload is in progress.
+ * @property isLoadingMore Whether pagination is loading more items at the bottom.
+ * @property hasMore Whether there are more pages of items to load.
+ * @property isOffline Whether the data was loaded from offline cache or the system is offline.
+ * @property errorMessage The error message to display if loading failed, or null.
+ * @property layoutType The active layout presentation type (LIST or GRID).
+ */
 @Immutable
 data class FeedState(
     val repos: ImmutableList<DiscoveryRepositoryUi> = persistentListOf(),

--- a/feature/feed/presentation/src/commonMain/kotlin/zed/rainxch/feed/presentation/FeedState.kt
+++ b/feature/feed/presentation/src/commonMain/kotlin/zed/rainxch/feed/presentation/FeedState.kt
@@ -8,6 +8,11 @@ import zed.rainxch.core.domain.model.repository.DiscoveryPlatform
 import zed.rainxch.core.presentation.model.DiscoveryRepositoryUi
 import zed.rainxch.core.domain.model.repository.FeedCategory
 
+enum class FeedLayoutType {
+    LIST,
+    GRID
+}
+
 @Immutable
 data class FeedState(
     val repos: ImmutableList<DiscoveryRepositoryUi> = persistentListOf(),
@@ -21,4 +26,5 @@ data class FeedState(
     val hasMore: Boolean = false,
     val isOffline: Boolean = false,
     val errorMessage: String? = null,
+    val layoutType: FeedLayoutType = FeedLayoutType.LIST,
 )

--- a/feature/feed/presentation/src/commonMain/kotlin/zed/rainxch/feed/presentation/FeedViewModel.kt
+++ b/feature/feed/presentation/src/commonMain/kotlin/zed/rainxch/feed/presentation/FeedViewModel.kt
@@ -132,6 +132,13 @@ class FeedViewModel(
                 browseFilterStore.setCategory(action.category)
             }
 
+            FeedAction.OnToggleLayoutType -> {
+                _state.update {
+                    val nextType = if (it.layoutType == FeedLayoutType.LIST) FeedLayoutType.GRID else FeedLayoutType.LIST
+                    it.copy(layoutType = nextType)
+                }
+            }
+
             is FeedAction.OnShareClick -> viewModelScope.launch {
                 runCatching {
                     shareManager.shareText("https://github-store.org/app?repo=${action.repo.fullName}")

--- a/feature/feed/presentation/src/commonMain/kotlin/zed/rainxch/feed/presentation/FeedViewModel.kt
+++ b/feature/feed/presentation/src/commonMain/kotlin/zed/rainxch/feed/presentation/FeedViewModel.kt
@@ -41,6 +41,10 @@ import zed.rainxch.githubstore.core.presentation.res.failed_to_share_link
 import zed.rainxch.githubstore.core.presentation.res.feed_failed_to_load
 import zed.rainxch.githubstore.core.presentation.res.link_copied_to_clipboard
 
+/**
+ * ViewModel responsible for managing the state, loading feed repositories,
+ * filtering by platforms and categories, and handling user interactions on the Feed screen.
+ */
 class FeedViewModel(
     private val feedRepository: FeedRepository,
     private val installedAppsRepository: InstalledAppsRepository,
@@ -104,6 +108,11 @@ class FeedViewModel(
     private val _events = Channel<FeedEvent>(capacity = Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
+    /**
+     * Handles UI actions dispatched from the feed composables.
+     *
+     * @param action The user action to process.
+     */
     fun onAction(action: FeedAction) {
         when (action) {
             FeedAction.OnRefresh -> reload(isRefresh = true)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
-networkTimeout=10000
+distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-8.14.3-bin.zip
+networkTimeout=60000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
1. Removed an annoying bug Strip or line (2nd head/nav mirror bug) A bug that was causing a black line space just above the NavBar!

Before

<img width="514" height="144" alt="black_line_nav" src="https://github.com/user-attachments/assets/7cfcbdd9-ace7-4165-b016-c1a1df5edd05" />

 
 After
 
<img width="514" height="89" alt="Screenshot 2026-08-08 at 6 11 50 AM" src="https://github.com/user-attachments/assets/ae53bebb-f3f4-47db-a2a0-24b9c398a08b" />

2. feat(feed): add layout toggler button and grid layout option and moved browsing selector to top Komi Store Header

before
<img width="274" height="583" alt="Screenshot 2026-08-08 at 5 25 53 AM" src="https://github.com/user-attachments/assets/40944848-1643-41f7-9abb-42df938c05d5" />


After
<img width="274" height="580" alt="Screenshot 2026-08-08 at 6 14 40 AM" src="https://github.com/user-attachments/assets/3cc903dc-e14c-499b-afd0-237af4065c01" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added list and adaptive grid layouts for the feed, with an easy layout toggle.
- Added platform selection controls to the feed’s top bar.
- Improved compact repository cards for grid views.

## Bug Fixes
- Improved content layout when the bottom navigation bar is visible.
- Prevented excessive spacing during navigation transitions.
- Ensured icon buttons consistently apply their configured sizes.

## Style
- Refined small button and icon button border thickness for a lighter appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->