### PR TITLE
fix: resolve clipped loader in Starred Repositories top bar

### DIFF
--- a/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposRoot.kt
+++ b/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposRoot.kt
@@ -298,12 +298,11 @@ private fun StarredTopBar(
         },
         actions = {
             if (isSyncing) {
-                KomiCircularProgress(
-                    modifier =
-                        Modifier
-                            .size(24.dp)
-                            .padding(end = 12.dp),
-                )
+                Box(modifier = Modifier.padding(end = 12.dp)) {
+                    KomiCircularProgress(
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
             }
 
             if (hasRepos) {


### PR DESCRIPTION
When loading starred repos, the loader was rendering incorrectly. This seems to be fixed by wrapping it in a Box.

### Before

<img width="400" alt="before" src="https://github.com/user-attachments/assets/dea03b97-fc66-4223-92c8-472579d4dec0" />
<img width="400" alt="before" src="https://github.com/user-attachments/assets/9e421fe6-200c-4f9e-bc0a-5e9bd2236a5c" />

### After

<img width="400" alt="after" src="https://github.com/user-attachments/assets/825e4624-3a4e-4584-92c0-b1ce6c6d6e70" />
<img width="400" alt="after" src="https://github.com/user-attachments/assets/65eb81a0-e3bf-47fd-9b68-76118a0a5fc2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing around the syncing progress indicator in the Starred Repositories screen.
  * Preserved the indicator’s appearance while aligning its surrounding layout more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->