### PR TITLE
fix: exclude ExploreScreen from restoreState in AppNavigation

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
@@ -121,7 +121,7 @@ fun AppNavigation(
                                     saveState = true
                                 }
                                 launchSingleTop = true
-                                restoreState = true
+                                restoreState = target != GithubStoreGraph.ExploreScreen
                             }
                         },
                         rail = rail,
@@ -1006,7 +1006,7 @@ fun AppNavigation(
                                     }
 
                                     launchSingleTop = true
-                                    restoreState = true
+                                    restoreState = it != GithubStoreGraph.ExploreScreen
                                 }
                             },
                             isUpdateAvailable = appsState.apps.any { it.installedApp.isUpdateAvailable },


### PR DESCRIPTION
This fixes a navigation bug where clicking "Explore" from the sidebar while on the Tweaks screen would fail to open the Explore page and instead reopen the Tweaks screen.

The issue was caused by `restoreState = true` mistakenly restoring the state of the recently popped Tweaks screen when navigating back to the root `ExploreScreen`. By explicitly excluding `ExploreScreen` from `restoreState` in `AppNavigation`, it now properly returns to Explore while keeping state restoration intact for all other tabs.

# Before

https://github.com/user-attachments/assets/009b731b-20c0-4393-a177-573c871a41dc


# After

https://github.com/user-attachments/assets/78205796-f874-4f05-8a51-188ef4d3e17a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Explore now opens with a fresh navigation state instead of restoring the previous screen.
  * Navigation state restoration remains available for other destinations across desktop and mobile navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->