### PR TITLE
fix(ui): align asset card spacing and animate picker height changes

### DIFF
--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ReleaseAssetsPicker.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ReleaseAssetsPicker.kt
@@ -1,5 +1,7 @@
 package zed.rainxch.details.presentation.components
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.tween
 import zed.rainxch.core.presentation.utils.formatFileSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -265,8 +267,10 @@ private fun ReleaseAssetsItemsPicker(
                 assetsList.map { it.id }.toSet()
             }
             LazyColumn(
-                modifier = Modifier.fillMaxWidth().heightIn(max = 420.dp),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                modifier = Modifier.fillMaxWidth()
+                    .animateContentSize(animationSpec = tween(durationMillis = 250))
+                    .heightIn(max = 420.dp),
+                contentPadding = PaddingValues(vertical = 8.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
 


### PR DESCRIPTION
Adjusts border margins and adds a smooth height transition animation to adapt to dynamic content.


<img width="1200" height="1335" alt="1345d1729a441ab53e31bfd16c03f014" src="https://github.com/user-attachments/assets/ef521596-97da-46dd-9f6b-254deafb2f86" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Added a smooth 250 ms animation when the release assets list changes size.
  - Adjusted the list layout to use vertical padding only, improving horizontal space usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->