### PR TITLE
fix(android): disable onBackInvokedCallback in AndroidManifest.xml

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -47,9 +47,11 @@
         <provider android:authorities="com.rosan.dhizuku.server.provider" />
     </queries>
 
+    <!-- targetSdk 36 enables this by default; CN OEMs often break it. -->
     <application
         android:name=".app.GithubStoreApp"
         android:allowBackup="true"
+        android:enableOnBackInvokedCallback="false"
         android:hasFragileUserData="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
Keep this disabled to avoid breaking predictive back gestures on some CN OEM systems.
