### PR TITLE
fix(android): scope silent installs to the current user (#718)

### DIFF
--- a/core/data/src/androidMain/aidl/zed/rainxch/core/data/services/dhizuku/IDhizukuInstallerService.aidl
+++ b/core/data/src/androidMain/aidl/zed/rainxch/core/data/services/dhizuku/IDhizukuInstallerService.aidl
@@ -1,7 +1,15 @@
 package zed.rainxch.core.data.services.dhizuku;
 
 interface IDhizukuInstallerService {
-    int installPackage(in ParcelFileDescriptor pfd, long fileSize, String expectedPackageName, long expectedVersionCode, String installerPackageName);
-    int uninstallPackage(String packageName);
+    int installPackage(
+        in ParcelFileDescriptor pfd,
+        long fileSize,
+        String expectedPackageName,
+        long expectedVersionCode,
+        String installerPackageName,
+        int userId,
+        int originatingUid
+    );
+    int uninstallPackage(String packageName, int userId);
     void destroy();
 }

--- a/core/data/src/androidMain/aidl/zed/rainxch/core/data/services/shizuku/IShizukuInstallerService.aidl
+++ b/core/data/src/androidMain/aidl/zed/rainxch/core/data/services/shizuku/IShizukuInstallerService.aidl
@@ -1,7 +1,14 @@
 package zed.rainxch.core.data.services.shizuku;
 
 interface IShizukuInstallerService {
-    int installPackage(in ParcelFileDescriptor pfd, long fileSize, String installerPackageName);
-    int uninstallPackage(String packageName);
-    void destroy();
+    int installPackage(
+        in ParcelFileDescriptor pfd,
+        long fileSize,
+        String packageName,
+        String installerPackageName,
+        int userId,
+        int originatingUid
+    ) = 1;
+    int uninstallPackage(String packageName, int userId) = 2;
+    void destroy() = 16777114;
 }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/di/PlatformModule.android.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/di/PlatformModule.android.kt
@@ -15,6 +15,7 @@ import zed.rainxch.core.data.services.AndroidDownloadProgressNotifier
 import zed.rainxch.core.data.services.AndroidFileLocationsProvider
 import zed.rainxch.core.data.services.AndroidInstaller
 import zed.rainxch.core.data.services.AndroidInstallerInfoExtractor
+import zed.rainxch.core.data.services.CurrentActivityHolder
 import zed.rainxch.core.data.services.AndroidLocalizationManager
 import zed.rainxch.core.data.services.AndroidPackageMonitor
 import zed.rainxch.core.data.services.AndroidPendingInstallNotifier
@@ -62,8 +63,9 @@ actual val corePlatformModule =
         }
 
         single {
+            CurrentActivityHolder.install(androidContext() as android.app.Application)
             AndroidInstaller(
-                context = get(),
+                context = androidContext(),
                 installerInfoExtractor = AndroidInstallerInfoExtractor(androidContext()),
             )
         }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidInstaller.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidInstaller.kt
@@ -9,14 +9,14 @@ import android.provider.Settings
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import co.touchlab.kermit.Logger
-import zed.rainxch.core.domain.utils.AssetArchitectureMatcher
-import zed.rainxch.core.domain.utils.AssetSelector
-import zed.rainxch.core.domain.utils.isAndroidApk
 import zed.rainxch.core.domain.model.account.github.GithubAsset
 import zed.rainxch.core.domain.model.system.SystemArchitecture
 import zed.rainxch.core.domain.system.InstallOutcome
 import zed.rainxch.core.domain.system.Installer
 import zed.rainxch.core.domain.system.InstallerInfoExtractor
+import zed.rainxch.core.domain.utils.AssetArchitectureMatcher
+import zed.rainxch.core.domain.utils.AssetSelector
+import zed.rainxch.core.domain.utils.isAndroidApk
 import java.io.File
 
 class AndroidInstaller(
@@ -92,25 +92,36 @@ class AndroidInstaller(
         }
 
         Logger.d { "Installing APK: $filePath" }
+        launchSystemPackageInstaller(file)
+        return InstallOutcome.DELEGATED_TO_SYSTEM
+    }
 
+    private fun launchSystemPackageInstaller(file: File) {
         val authority = "${context.packageName}.fileprovider"
         val fileUri: Uri = FileProvider.getUriForFile(context, authority, file)
-
         val intent =
             Intent(Intent.ACTION_VIEW).apply {
                 setDataAndType(fileUri, "application/vnd.android.package-archive")
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
             }
 
-        if (intent.resolveActivity(context.packageManager) != null) {
-            context.startActivity(intent)
-            Logger.d { "APK installation intent launched" }
-        } else {
+        val launchContext = CurrentActivityHolder.activity() ?: context
+        if (intent.resolveActivity(launchContext.packageManager) == null) {
             throw IllegalStateException("No installer available on this device")
         }
 
-        return InstallOutcome.DELEGATED_TO_SYSTEM
+        val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+        launchContext.packageManager
+            .queryIntentActivities(intent, 0)
+            .forEach { info ->
+                launchContext.grantUriPermission(info.activityInfo.packageName, fileUri, flags)
+            }
+
+        launchContext.startActivity(intent)
+        Logger.d { "APK installation intent launched via ${launchContext.javaClass.simpleName}" }
     }
 
     override fun uninstall(packageName: String) {

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/CurrentActivityHolder.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/CurrentActivityHolder.kt
@@ -1,0 +1,49 @@
+package zed.rainxch.core.data.services
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import java.lang.ref.WeakReference
+
+object CurrentActivityHolder : Application.ActivityLifecycleCallbacks {
+    @Volatile
+    private var installed = false
+
+    private var resumed: WeakReference<Activity> = WeakReference(null)
+
+    fun install(application: Application) {
+        if (installed) return
+        installed = true
+        application.registerActivityLifecycleCallbacks(this)
+    }
+
+    fun activity(): Activity? {
+        val current = resumed.get() ?: return null
+        if (current.isFinishing || current.isDestroyed) return null
+        return current
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+
+    override fun onActivityStarted(activity: Activity) = Unit
+
+    override fun onActivityResumed(activity: Activity) {
+        resumed = WeakReference(activity)
+    }
+
+    override fun onActivityPaused(activity: Activity) {
+        if (resumed.get() === activity) {
+            resumed = WeakReference(null)
+        }
+    }
+
+    override fun onActivityStopped(activity: Activity) = Unit
+
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+
+    override fun onActivityDestroyed(activity: Activity) {
+        if (resumed.get() === activity) {
+            resumed = WeakReference(null)
+        }
+    }
+}

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/dhizuku/DhizukuInstallerServiceImpl.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/dhizuku/DhizukuInstallerServiceImpl.kt
@@ -1,36 +1,24 @@
 package zed.rainxch.core.data.services.dhizuku
 
-import android.app.PendingIntent
-import android.content.BroadcastReceiver
 import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
-import android.content.pm.PackageInstaller
-import android.os.Build
+import android.content.pm.PackageManager
 import android.os.ParcelFileDescriptor
-import java.util.UUID
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
+import com.rosan.dhizuku.api.Dhizuku
+import zed.rainxch.core.data.services.installer.PackageSessionInstaller
 
 class DhizukuInstallerServiceImpl() : IDhizukuInstallerService.Stub() {
 
     companion object {
         private const val TAG = "DhizukuService"
-
-        private const val STATUS_SUCCESS = 0
-        private const val STATUS_FAILURE = -1
-
-        const val STATUS_PENDING_USER_ACTION_REQUIRED = -2
-        private const val INSTALL_TIMEOUT_SECONDS = 120L
-        private const val UNINSTALL_TIMEOUT_SECONDS = 30L
-
-        private const val ACTION_INSTALL_RESULT = "zed.rainxch.dhizuku.INSTALL_RESULT"
-        private const val ACTION_UNINSTALL_RESULT = "zed.rainxch.dhizuku.UNINSTALL_RESULT"
-
         private fun log(msg: String) = android.util.Log.d(TAG, msg)
-        private fun logW(msg: String) = android.util.Log.w(TAG, msg)
         private fun logE(msg: String, e: Throwable? = null) = android.util.Log.e(TAG, msg, e)
+
+        private fun ownerPackageName(ctx: Context): String {
+            val owner = runCatching {
+                if (Dhizuku.init(ctx)) Dhizuku.getOwnerPackageName() else null
+            }.getOrNull()?.takeIf { it.isNotBlank() }
+            return owner ?: ctx.packageName
+        }
     }
 
     override fun installPackage(
@@ -39,253 +27,60 @@ class DhizukuInstallerServiceImpl() : IDhizukuInstallerService.Stub() {
         expectedPackageName: String?,
         expectedVersionCode: Long,
         installerPackageName: String?,
+        userId: Int,
+        originatingUid: Int,
     ): Int {
-        log("installPackage() called — fileSize=$fileSize, expected=$expectedPackageName@$expectedVersionCode, installer=$installerPackageName")
-        log("Process UID: ${android.os.Process.myUid()}, PID: ${android.os.Process.myPid()}")
-
-        val ctx: Context = currentApplicationOrNull() ?: run {
-            logE("currentApplication() returned null — no context available")
-            return STATUS_FAILURE
+        log(
+            "installPackage() fileSize=$fileSize expected=$expectedPackageName@$expectedVersionCode " +
+                "userId=$userId installer=$installerPackageName",
+        )
+        val ctx = PackageSessionInstaller.currentApplicationOrNull() ?: run {
+            logE("currentApplication() returned null")
+            return PackageSessionInstaller.STATUS_FAILURE
         }
-
-        val installer = ctx.packageManager.packageInstaller
-        val params = PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            params.setRequireUserAction(PackageInstaller.SessionParams.USER_ACTION_NOT_REQUIRED)
-        }
-        if (fileSize > 0) params.setSize(fileSize)
-        installerPackageName?.takeIf { it.isNotBlank() }?.let { name ->
-            try {
-                params.setInstallerPackageName(name)
-            } catch (e: Exception) {
-                logW("setInstallerPackageName($name) failed: ${e.message}")
-            }
-        }
-
-        var sessionId = -1
-        var session: PackageInstaller.Session? = null
-        var receiver: BroadcastReceiver? = null
-        var committed = false
+        val owner = ownerPackageName(ctx)
         return try {
-            sessionId = installer.createSession(params)
-            log("createSession() — sessionId=$sessionId")
-            session = installer.openSession(sessionId)
-
-            session.openWrite("apk", 0, fileSize).use { out ->
-                ParcelFileDescriptor.AutoCloseInputStream(pfd).use { input ->
-                    val copied = input.copyTo(out)
-                    out.flush()
-                    session.fsync(out)
-                    log("APK piped to session: $copied bytes (expected: $fileSize)")
-                }
-            }
-
-            val latch = CountDownLatch(1)
-            val resultRef = AtomicInteger(STATUS_FAILURE)
-            val token = UUID.randomUUID().toString()
-            val action = "$ACTION_INSTALL_RESULT.$token"
-
-            receiver = object : BroadcastReceiver() {
-                override fun onReceive(context: Context, intent: Intent) {
-                    val status = intent.getIntExtra(
-                        PackageInstaller.EXTRA_STATUS,
-                        PackageInstaller.STATUS_FAILURE,
-                    )
-                    val message = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
-                    log("install result — status=$status, message='$message'")
-                    when (status) {
-                        PackageInstaller.STATUS_SUCCESS -> resultRef.set(STATUS_SUCCESS)
-                        PackageInstaller.STATUS_PENDING_USER_ACTION -> {
-
-                            logW("install requires user action (Android 14+ update-ownership gate) — installerAttribution=$installerPackageName")
-                            resultRef.set(STATUS_PENDING_USER_ACTION_REQUIRED)
-                        }
-                        else -> {
-                            logW("install failed status=$status: $message")
-                            resultRef.set(STATUS_FAILURE)
-                        }
-                    }
-                    latch.countDown()
-                }
-            }
-            registerInternalReceiver(ctx, receiver, action)
-
-            val pendingFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
-            } else {
-                PendingIntent.FLAG_UPDATE_CURRENT
-            }
-            val pendingIntent = PendingIntent.getBroadcast(
-                ctx,
-                token.hashCode(),
-                Intent(action).setPackage(ctx.packageName),
-                pendingFlags,
+            PackageSessionInstaller.installFromPfd(
+                context = ctx,
+                pfd = pfd,
+                fileSize = fileSize,
+                packageName = expectedPackageName,
+                expectedVersionCode = expectedVersionCode,
+                installerPackageName = installerPackageName,
+                callerPackageName = owner,
+                userId = userId,
+                originatingUid = originatingUid,
+                privileged = true,
+                installReason = PackageManager.INSTALL_REASON_POLICY,
             )
-
-            session.commit(pendingIntent.intentSender)
-            committed = true
-            log("session.commit() called, awaiting result...")
-
-            val finished = latch.await(INSTALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            if (!finished) {
-                logE("install timed out after ${INSTALL_TIMEOUT_SECONDS}s — verifying package state")
-                if (verifyInstallSucceeded(ctx, installer, sessionId, expectedPackageName, expectedVersionCode)) {
-                    log("post-timeout verification confirmed install succeeded")
-                    STATUS_SUCCESS
-                } else {
-                    logE("post-timeout verification could not confirm install")
-                    STATUS_FAILURE
-                }
-            } else {
-                resultRef.get()
-            }
         } catch (e: Exception) {
             logE("installPackage() exception", e)
-            STATUS_FAILURE
-        } finally {
-            if (!committed && sessionId >= 0) {
-                try { installer.abandonSession(sessionId) } catch (_: Exception) {}
-            }
-            try { session?.close() } catch (_: Exception) {}
-            if (receiver != null) {
-                try { ctx.unregisterReceiver(receiver) } catch (_: Exception) {}
-            }
+            PackageSessionInstaller.STATUS_FAILURE
         }
     }
 
-    override fun uninstallPackage(packageName: String): Int {
-        log("uninstallPackage() called for: $packageName")
-
-        val ctx: Context = currentApplicationOrNull() ?: run {
-            logE("currentApplication() returned null — no context available")
-            return STATUS_FAILURE
+    override fun uninstallPackage(packageName: String, userId: Int): Int {
+        log("uninstallPackage() pkg=$packageName userId=$userId")
+        val ctx = PackageSessionInstaller.currentApplicationOrNull() ?: run {
+            logE("currentApplication() returned null")
+            return PackageSessionInstaller.STATUS_FAILURE
         }
-
-        val installer = ctx.packageManager.packageInstaller
-        val latch = CountDownLatch(1)
-        val resultRef = AtomicInteger(STATUS_FAILURE)
-        val token = UUID.randomUUID().toString()
-        val action = "$ACTION_UNINSTALL_RESULT.$token"
-        var receiver: BroadcastReceiver? = null
-
         return try {
-            receiver = object : BroadcastReceiver() {
-                override fun onReceive(context: Context, intent: Intent) {
-                    val status = intent.getIntExtra(
-                        PackageInstaller.EXTRA_STATUS,
-                        PackageInstaller.STATUS_FAILURE,
-                    )
-                    val message = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
-                    log("uninstall result — status=$status, message='$message'")
-                    resultRef.set(if (status == PackageInstaller.STATUS_SUCCESS) STATUS_SUCCESS else STATUS_FAILURE)
-                    latch.countDown()
-                }
-            }
-            registerInternalReceiver(ctx, receiver, action)
-
-            val pendingFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
-            } else {
-                PendingIntent.FLAG_UPDATE_CURRENT
-            }
-            val pendingIntent = PendingIntent.getBroadcast(
-                ctx,
-                token.hashCode(),
-                Intent(action).setPackage(ctx.packageName),
-                pendingFlags,
+            PackageSessionInstaller.uninstall(
+                context = ctx,
+                packageName = packageName,
+                userId = userId,
+                privileged = true,
+                callerPackageName = ownerPackageName(ctx),
             )
-
-            installer.uninstall(packageName, pendingIntent.intentSender)
-
-            val finished = latch.await(UNINSTALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            if (!finished) {
-                logE("uninstall timed out after ${UNINSTALL_TIMEOUT_SECONDS}s — verifying package state")
-                if (!isPackageInstalled(ctx, packageName)) {
-                    log("post-timeout verification confirmed uninstall succeeded")
-                    STATUS_SUCCESS
-                } else {
-                    logE("post-timeout verification: package still installed")
-                    STATUS_FAILURE
-                }
-            } else {
-                resultRef.get()
-            }
         } catch (e: Exception) {
             logE("uninstallPackage() exception", e)
-            STATUS_FAILURE
-        } finally {
-            if (receiver != null) {
-                try { ctx.unregisterReceiver(receiver) } catch (_: Exception) {}
-            }
+            PackageSessionInstaller.STATUS_FAILURE
         }
     }
 
     override fun destroy() {
         log("destroy() — service being unbound")
-    }
-
-    private fun verifyInstallSucceeded(
-        ctx: Context,
-        installer: PackageInstaller,
-        sessionId: Int,
-        expectedPackageName: String?,
-        expectedVersionCode: Long,
-    ): Boolean {
-        val targetPackage = expectedPackageName?.takeIf { it.isNotBlank() }
-            ?: runCatching { installer.getSessionInfo(sessionId)?.appPackageName }
-                .onFailure { logE("getSessionInfo() failed during verification", it) }
-                .getOrNull()
-            ?: return false
-        val info = packageInfoOrNull(ctx, targetPackage) ?: return false
-        if (expectedVersionCode <= 0L) return true
-        val installedVersion = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            info.longVersionCode
-        } else {
-            @Suppress("DEPRECATION")
-            info.versionCode.toLong()
-        }
-        val matches = installedVersion >= expectedVersionCode
-        if (!matches) {
-            logW("installed $targetPackage@$installedVersion does not match expected@$expectedVersionCode")
-        }
-        return matches
-    }
-
-    private fun isPackageInstalled(ctx: Context, packageName: String): Boolean =
-        packageInfoOrNull(ctx, packageName) != null
-
-    private fun packageInfoOrNull(ctx: Context, packageName: String): android.content.pm.PackageInfo? = try {
-        ctx.packageManager.getPackageInfo(packageName, 0)
-    } catch (_: android.content.pm.PackageManager.NameNotFoundException) {
-        null
-    } catch (e: Exception) {
-        logE("getPackageInfo($packageName) failed", e)
-        null
-    }
-
-    private fun currentApplicationOrNull(): Context? {
-        return try {
-            val cls = Class.forName("android.app.ActivityThread")
-            val app = cls.getMethod("currentApplication").invoke(null)
-            app as? Context
-        } catch (e: Exception) {
-            try {
-                val cls = Class.forName("android.app.AppGlobals")
-                val app = cls.getMethod("getInitialApplication").invoke(null)
-                app as? Context
-            } catch (_: Exception) {
-                logE("Failed to obtain Application context", e)
-                null
-            }
-        }
-    }
-
-    private fun registerInternalReceiver(ctx: Context, receiver: BroadcastReceiver, action: String) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            ctx.registerReceiver(receiver, IntentFilter(action), Context.RECEIVER_NOT_EXPORTED)
-        } else {
-            @Suppress("UnspecifiedRegisterReceiverFlag")
-            ctx.registerReceiver(receiver, IntentFilter(action))
-        }
+        System.exit(0)
     }
 }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/installer/PackageSessionInstaller.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/installer/PackageSessionInstaller.kt
@@ -1,0 +1,518 @@
+package zed.rainxch.core.data.services.installer
+
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageInstaller
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.IBinder
+import android.os.ParcelFileDescriptor
+import java.io.InputStream
+import java.util.UUID
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+object PackageSessionInstaller {
+    const val STATUS_SUCCESS = 0
+    const val STATUS_FAILURE = -1
+    const val STATUS_PENDING_USER_ACTION_REQUIRED = -2
+    const val STATUS_ABORTED = -3
+
+    private const val TAG = "PkgSessionInstaller"
+    private const val INSTALL_REPLACE_EXISTING = 0x00000002
+    private const val INSTALL_TIMEOUT_SECONDS = 120L
+    private const val INSTALL_POLL_MS = 400L
+    private const val UNINSTALL_TIMEOUT_SECONDS = 30L
+    private const val ACTION_INSTALL_RESULT = "zed.rainxch.githubstore.SESSION_INSTALL"
+    private const val ACTION_UNINSTALL_RESULT = "zed.rainxch.githubstore.SESSION_UNINSTALL"
+
+    fun appUserId(): Int = android.os.Process.myUid() / 100_000
+
+    fun currentApplicationOrNull(): Context? {
+        return try {
+            val cls = Class.forName("android.app.ActivityThread")
+            cls.getMethod("currentApplication").invoke(null) as? Context
+        } catch (e: Exception) {
+            try {
+                val cls = Class.forName("android.app.AppGlobals")
+                cls.getMethod("getInitialApplication").invoke(null) as? Context
+            } catch (_: Exception) {
+                logE("Failed to obtain Application context", e)
+                null
+            }
+        }
+    }
+
+    fun readApkIdentity(context: Context, filePath: String): Pair<String?, Long> {
+        val info = try {
+            context.packageManager.getPackageArchiveInfo(filePath, 0)
+        } catch (e: Exception) {
+            logW("getPackageArchiveInfo($filePath) failed: ${e.message}")
+            null
+        } ?: return null to -1L
+        val versionCode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            info.versionCode.toLong()
+        }
+        return info.packageName to versionCode
+    }
+
+    fun installFromPfd(
+        context: Context,
+        pfd: ParcelFileDescriptor,
+        fileSize: Long,
+        packageName: String?,
+        expectedVersionCode: Long,
+        installerPackageName: String?,
+        callerPackageName: String?,
+        userId: Int,
+        originatingUid: Int,
+        privileged: Boolean,
+        installReason: Int = -1,
+    ): Int {
+        ParcelFileDescriptor.AutoCloseInputStream(pfd).use { input ->
+            return install(
+                context = context,
+                input = input,
+                fileSize = fileSize,
+                packageName = packageName,
+                expectedVersionCode = expectedVersionCode,
+                installerPackageName = installerPackageName,
+                callerPackageName = callerPackageName,
+                userId = userId,
+                originatingUid = originatingUid,
+                privileged = privileged,
+                installReason = installReason,
+            )
+        }
+    }
+
+    fun install(
+        context: Context,
+        input: InputStream,
+        fileSize: Long,
+        packageName: String?,
+        expectedVersionCode: Long,
+        installerPackageName: String?,
+        callerPackageName: String?,
+        userId: Int,
+        originatingUid: Int,
+        privileged: Boolean,
+        installReason: Int = -1,
+    ): Int {
+        val resolvedUserId = userId.coerceAtLeast(0)
+        val caller = callerPackageName?.takeIf { it.isNotBlank() } ?: context.packageName
+        log(
+            "install() privileged=$privileged userId=$resolvedUserId pkg=$packageName " +
+                "caller=$caller installer=$installerPackageName originatingUid=$originatingUid " +
+                "installReason=$installReason",
+        )
+
+        val installer = resolvePackageInstaller(context, privileged, caller, resolvedUserId)
+            ?: run {
+                logE("resolvePackageInstaller() returned null")
+                return STATUS_FAILURE
+            }
+
+        val params = PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
+        packageName?.takeIf { it.isNotBlank() }?.let { params.setAppPackageName(it) }
+        if (fileSize > 0) params.setSize(fileSize)
+        if (originatingUid >= 0) {
+            try {
+                params.setOriginatingUid(originatingUid)
+            } catch (e: Exception) {
+                logW("setOriginatingUid($originatingUid) failed: ${e.message}")
+            }
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            params.setRequireUserAction(PackageInstaller.SessionParams.USER_ACTION_NOT_REQUIRED)
+        }
+        if (installReason >= 0) {
+            try {
+                params.setInstallReason(installReason)
+            } catch (e: Exception) {
+                logW("setInstallReason($installReason) failed: ${e.message}")
+            }
+        }
+        installerPackageName?.takeIf { it.isNotBlank() }?.let { name ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                try {
+                    params.setInstallerPackageName(name)
+                } catch (e: Exception) {
+                    logW("setInstallerPackageName($name) failed: ${e.message}")
+                }
+            }
+        }
+        addReplaceExistingFlag(params)
+
+        var sessionId = -1
+        var session: PackageInstaller.Session? = null
+        var receiver: BroadcastReceiver? = null
+        var sessionCallback: PackageInstaller.SessionCallback? = null
+        var callbackThread: HandlerThread? = null
+        var committed = false
+        val results = LinkedBlockingQueue<Intent>()
+        return try {
+            sessionId = installer.createSession(params)
+            log("createSession() sessionId=$sessionId")
+            session = installer.openSession(sessionId)
+            val writeLength = if (fileSize > 0) fileSize else -1L
+            session.openWrite("base.apk", 0, writeLength).use { out ->
+                val copied = input.copyTo(out)
+                out.flush()
+                session.fsync(out)
+                log("APK written to session: $copied bytes (expected: $fileSize)")
+            }
+
+            val token = UUID.randomUUID().toString()
+            val action = "$ACTION_INSTALL_RESULT.$token"
+            receiver = object : BroadcastReceiver() {
+                override fun onReceive(ctx: Context, intent: Intent) {
+                    results.offer(intent)
+                }
+            }
+            registerInternalReceiver(context, receiver, action)
+            val finished = registerFinishedCallback(installer, sessionId, results)
+            sessionCallback = finished?.first
+            callbackThread = finished?.second
+            session.commit(broadcastSender(context, action, token.hashCode()))
+            committed = true
+
+            awaitInstallStatus(
+                context = context,
+                results = results,
+                launchConfirmOnPending = !privileged,
+                packageName = packageName,
+            )
+        } catch (e: Exception) {
+            logE("install() exception", e)
+            STATUS_FAILURE
+        } finally {
+            if (!committed && sessionId >= 0) {
+                try {
+                    installer.abandonSession(sessionId)
+                } catch (_: Exception) {
+                }
+            }
+            try {
+                session?.close()
+            } catch (_: Exception) {
+            }
+            if (sessionCallback != null) {
+                try {
+                    installer.unregisterSessionCallback(sessionCallback)
+                } catch (_: Exception) {
+                }
+            }
+            callbackThread?.quitSafely()
+            if (receiver != null) {
+                try {
+                    context.unregisterReceiver(receiver)
+                } catch (_: Exception) {
+                }
+            }
+        }
+    }
+
+    fun uninstall(
+        context: Context,
+        packageName: String,
+        userId: Int,
+        privileged: Boolean,
+        callerPackageName: String?,
+    ): Int {
+        val resolvedUserId = userId.coerceAtLeast(0)
+        val caller = callerPackageName?.takeIf { it.isNotBlank() } ?: context.packageName
+        log("uninstall() pkg=$packageName userId=$resolvedUserId privileged=$privileged")
+
+        val installer = resolvePackageInstaller(context, privileged, caller, resolvedUserId)
+            ?: run {
+                logE("resolvePackageInstaller() returned null")
+                return STATUS_FAILURE
+            }
+
+        val results = LinkedBlockingQueue<Intent>()
+        var receiver: BroadcastReceiver? = null
+        return try {
+            val token = UUID.randomUUID().toString()
+            val action = "$ACTION_UNINSTALL_RESULT.$token"
+            receiver = object : BroadcastReceiver() {
+                override fun onReceive(ctx: Context, intent: Intent) {
+                    results.offer(intent)
+                }
+            }
+            registerInternalReceiver(context, receiver, action)
+            installer.uninstall(packageName, broadcastSender(context, action, token.hashCode()))
+
+            val intent = results.poll(UNINSTALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            if (intent == null) {
+                logE("uninstall timed out after ${UNINSTALL_TIMEOUT_SECONDS}s")
+                return if (!isPackageInstalled(context, packageName)) STATUS_SUCCESS else STATUS_FAILURE
+            }
+            val status = intent.getIntExtra(
+                PackageInstaller.EXTRA_STATUS,
+                PackageInstaller.STATUS_FAILURE,
+            )
+            log("uninstall result status=$status message=${intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)}")
+            if (status == PackageInstaller.STATUS_SUCCESS) STATUS_SUCCESS else STATUS_FAILURE
+        } catch (e: Exception) {
+            logE("uninstall() exception", e)
+            STATUS_FAILURE
+        } finally {
+            if (receiver != null) {
+                try {
+                    context.unregisterReceiver(receiver)
+                } catch (_: Exception) {
+                }
+            }
+        }
+    }
+
+    private fun awaitInstallStatus(
+        context: Context,
+        results: LinkedBlockingQueue<Intent>,
+        launchConfirmOnPending: Boolean,
+        packageName: String?,
+    ): Int {
+        val baselineVersion = installedVersionOrNull(context, packageName)
+        val deadlineNs = System.nanoTime() + TimeUnit.SECONDS.toNanos(INSTALL_TIMEOUT_SECONDS)
+        while (true) {
+            if (installVisibleOnDevice(context, packageName, baselineVersion)) {
+                log("package state changed on device, treating install as success")
+                return STATUS_SUCCESS
+            }
+            val remainingNs = deadlineNs - System.nanoTime()
+            if (remainingNs <= 0L) {
+                logE("install timed out after ${INSTALL_TIMEOUT_SECONDS}s")
+                if (installVisibleOnDevice(context, packageName, baselineVersion)) {
+                    return STATUS_SUCCESS
+                }
+                return STATUS_FAILURE
+            }
+            val waitNs = minOf(remainingNs, TimeUnit.MILLISECONDS.toNanos(INSTALL_POLL_MS))
+            val intent = results.poll(waitNs, TimeUnit.NANOSECONDS) ?: continue
+            val status = intent.getIntExtra(
+                PackageInstaller.EXTRA_STATUS,
+                PackageInstaller.STATUS_FAILURE,
+            )
+            val message = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
+            log("install result status=$status message='$message'")
+            when (status) {
+                PackageInstaller.STATUS_SUCCESS -> return STATUS_SUCCESS
+                PackageInstaller.STATUS_PENDING_USER_ACTION -> {
+                    if (!launchConfirmOnPending) {
+                        return STATUS_PENDING_USER_ACTION_REQUIRED
+                    }
+                    val confirm = extraIntent(intent) ?: run {
+                        logW("PENDING_USER_ACTION without EXTRA_INTENT")
+                        return STATUS_PENDING_USER_ACTION_REQUIRED
+                    }
+                    try {
+                        confirm.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        context.startActivity(confirm)
+                        log("launched system confirm activity")
+                    } catch (e: Exception) {
+                        logE("failed to launch confirm activity", e)
+                        return STATUS_PENDING_USER_ACTION_REQUIRED
+                    }
+                }
+                PackageInstaller.STATUS_FAILURE_ABORTED -> return STATUS_ABORTED
+                else -> return STATUS_FAILURE
+            }
+        }
+    }
+
+    private fun registerFinishedCallback(
+        installer: PackageInstaller,
+        sessionId: Int,
+        results: LinkedBlockingQueue<Intent>,
+    ): Pair<PackageInstaller.SessionCallback, HandlerThread>? {
+        val thread = HandlerThread("PkgSessionCb").apply { start() }
+        val callback = object : PackageInstaller.SessionCallback() {
+            override fun onCreated(id: Int) = Unit
+            override fun onBadgingChanged(id: Int) = Unit
+            override fun onActiveChanged(id: Int, active: Boolean) = Unit
+            override fun onProgressChanged(id: Int, progress: Float) = Unit
+            override fun onFinished(id: Int, success: Boolean) {
+                if (id != sessionId || !success) return
+                log("SessionCallback.onFinished sessionId=$id success=$success")
+                results.offer(
+                    Intent().putExtra(
+                        PackageInstaller.EXTRA_STATUS,
+                        PackageInstaller.STATUS_SUCCESS,
+                    ),
+                )
+            }
+        }
+        return try {
+            installer.registerSessionCallback(callback, Handler(thread.looper))
+            callback to thread
+        } catch (e: Exception) {
+            logW("registerSessionCallback failed: ${e.message}")
+            thread.quitSafely()
+            null
+        }
+    }
+
+    private fun resolvePackageInstaller(
+        context: Context,
+        privileged: Boolean,
+        callerPackageName: String,
+        userId: Int,
+    ): PackageInstaller? {
+        if (!privileged) {
+            return context.packageManager.packageInstaller
+        }
+        val iPackageInstaller = resolveIPackageInstaller(context) ?: return null
+        return createPrivilegedPackageInstaller(iPackageInstaller, callerPackageName, userId)
+    }
+
+    private fun resolveIPackageInstaller(context: Context): Any? {
+        try {
+            val publicInstaller = context.packageManager.packageInstaller
+            val field = PackageInstaller::class.java.getDeclaredField("mInstaller")
+            field.isAccessible = true
+            return field.get(publicInstaller)
+        } catch (e: Exception) {
+            logW("mInstaller field lookup failed: ${e.message}")
+        }
+        return try {
+            val serviceManager = Class.forName("android.os.ServiceManager")
+            val binder = serviceManager
+                .getMethod("getService", String::class.java)
+                .invoke(null, "package") as IBinder
+            val stub = Class.forName("android.content.pm.IPackageManager\$Stub")
+            val ipm = stub.getMethod("asInterface", IBinder::class.java).invoke(null, binder)
+            ipm.javaClass.getMethod("getPackageInstaller").invoke(ipm)
+        } catch (e: Exception) {
+            logW("ServiceManager IPackageInstaller lookup failed: ${e.message}")
+            null
+        }
+    }
+
+    private fun createPrivilegedPackageInstaller(
+        iPackageInstaller: Any,
+        callerPackageName: String,
+        userId: Int,
+    ): PackageInstaller? {
+        val ipiClass = try {
+            Class.forName("android.content.pm.IPackageInstaller")
+        } catch (e: Exception) {
+            logW("IPackageInstaller class not found: ${e.message}")
+            return null
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            try {
+                val ctor = PackageInstaller::class.java.getDeclaredConstructor(
+                    ipiClass,
+                    String::class.java,
+                    String::class.java,
+                    Int::class.javaPrimitiveType,
+                )
+                ctor.isAccessible = true
+                return ctor.newInstance(iPackageInstaller, callerPackageName, null, userId) as PackageInstaller
+            } catch (e: Exception) {
+                logW("PackageInstaller(S+) constructor failed: ${e.message}")
+            }
+        }
+        return try {
+            val ctor = PackageInstaller::class.java.getDeclaredConstructor(
+                ipiClass,
+                String::class.java,
+                Int::class.javaPrimitiveType,
+            )
+            ctor.isAccessible = true
+            ctor.newInstance(iPackageInstaller, callerPackageName, userId) as PackageInstaller
+        } catch (e: Exception) {
+            logE("PackageInstaller constructor failed", e)
+            null
+        }
+    }
+
+    private fun addReplaceExistingFlag(params: PackageInstaller.SessionParams) {
+        for (name in arrayOf("installFlags", "mInstallFlags")) {
+            try {
+                val field = params.javaClass.getDeclaredField(name)
+                field.isAccessible = true
+                field.setInt(params, field.getInt(params) or INSTALL_REPLACE_EXISTING)
+                return
+            } catch (_: Exception) {
+            }
+        }
+        logW("could not set INSTALL_REPLACE_EXISTING")
+    }
+
+    private fun broadcastSender(context: Context, action: String, requestCode: Int): android.content.IntentSender {
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+        } else {
+            PendingIntent.FLAG_UPDATE_CURRENT
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            requestCode,
+            Intent(action).setPackage(context.packageName),
+            flags,
+        ).intentSender
+    }
+
+    private fun extraIntent(intent: Intent): Intent? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableExtra(Intent.EXTRA_INTENT)
+        }
+
+    private fun installVisibleOnDevice(
+        ctx: Context,
+        packageName: String?,
+        baselineVersion: Long?,
+    ): Boolean {
+        val installed = installedVersionOrNull(ctx, packageName) ?: return false
+        return baselineVersion == null || installed > baselineVersion
+    }
+
+    private fun installedVersionOrNull(ctx: Context, packageName: String?): Long? {
+        val target = packageName?.takeIf { it.isNotBlank() } ?: return null
+        val info = packageInfoOrNull(ctx, target) ?: return null
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            info.versionCode.toLong()
+        }
+    }
+
+    private fun isPackageInstalled(ctx: Context, packageName: String): Boolean =
+        packageInfoOrNull(ctx, packageName) != null
+
+    private fun packageInfoOrNull(ctx: Context, packageName: String): android.content.pm.PackageInfo? = try {
+        ctx.packageManager.getPackageInfo(packageName, 0)
+    } catch (_: PackageManager.NameNotFoundException) {
+        null
+    } catch (e: Exception) {
+        logE("getPackageInfo($packageName) failed", e)
+        null
+    }
+
+    private fun registerInternalReceiver(ctx: Context, receiver: BroadcastReceiver, action: String) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ctx.registerReceiver(receiver, IntentFilter(action), Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            @Suppress("UnspecifiedRegisterReceiverFlag")
+            ctx.registerReceiver(receiver, IntentFilter(action))
+        }
+    }
+
+    private fun log(msg: String) = android.util.Log.d(TAG, msg)
+    private fun logW(msg: String) = android.util.Log.w(TAG, msg)
+    private fun logE(msg: String, e: Throwable? = null) = android.util.Log.e(TAG, msg, e)
+}

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/installer/SilentInstallerDispatcher.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/installer/SilentInstallerDispatcher.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import zed.rainxch.core.data.services.dhizuku.DhizukuInstallerServiceImpl
 import zed.rainxch.core.data.services.dhizuku.DhizukuServiceManager
 import zed.rainxch.core.data.services.dhizuku.model.DhizukuStatus
 import zed.rainxch.core.data.services.root.RootServiceManager
@@ -133,25 +132,43 @@ class SilentInstallerDispatcher(
     private suspend fun trySilentInstall(filePath: String, backend: Backend): InstallOutcome? {
         Logger.d(TAG) { "Routing install through $backend" }
         val installerAttribution = cachedInstallerAttribution.resolvePackageName()
+        val userId = PackageSessionInstaller.appUserId()
+        val originatingUid = android.os.Process.myUid()
         return try {
             val file = File(filePath)
-            val (expectedPkg, expectedVc) = readApkIdentity(filePath)
+            val (expectedPkg, expectedVc) = PackageSessionInstaller.readApkIdentity(androidContext, filePath)
             val first =
                 withContext(Dispatchers.IO) {
-                    runInstall(file, backend, installerAttribution, expectedPkg, expectedVc)
+                    runInstall(
+                        file = file,
+                        backend = backend,
+                        installerAttribution = installerAttribution,
+                        expectedPkg = expectedPkg,
+                        expectedVc = expectedVc,
+                        userId = userId,
+                        originatingUid = originatingUid,
+                    )
                 }
 
             val resolved =
                 if (
                     backend == Backend.DHIZUKU &&
-                    first == DhizukuInstallerServiceImpl.STATUS_PENDING_USER_ACTION_REQUIRED &&
+                    first == PackageSessionInstaller.STATUS_PENDING_USER_ACTION_REQUIRED &&
                     !installerAttribution.isNullOrBlank()
                 ) {
                     Logger.w(TAG) {
                         "Dhizuku returned PENDING_USER_ACTION with attribution=$installerAttribution; retrying without attribution"
                     }
                     withContext(Dispatchers.IO) {
-                        runInstall(file, backend, null, expectedPkg, expectedVc)
+                        runInstall(
+                            file = file,
+                            backend = backend,
+                            installerAttribution = null,
+                            expectedPkg = expectedPkg,
+                            expectedVc = expectedVc,
+                            userId = userId,
+                            originatingUid = originatingUid,
+                        )
                     }
                 } else {
                     first
@@ -161,12 +178,17 @@ class SilentInstallerDispatcher(
                     Logger.w(TAG) { "$backend service is null, will fall back" }
                     null
                 }
-                resolved == 0 -> InstallOutcome.COMPLETED
+                resolved == PackageSessionInstaller.STATUS_SUCCESS -> InstallOutcome.COMPLETED
+                resolved == PackageSessionInstaller.STATUS_ABORTED -> {
+                    throw IllegalStateException("Installation cancelled")
+                }
                 else -> {
                     Logger.w(TAG) { "$backend install returned $resolved, will fall back" }
                     null
                 }
             }
+        } catch (e: IllegalStateException) {
+            throw e
         } catch (e: Exception) {
             Logger.e(TAG) { "$backend install exception, falling back: ${e.javaClass.simpleName}: ${e.message}" }
             null
@@ -179,55 +201,60 @@ class SilentInstallerDispatcher(
         installerAttribution: String?,
         expectedPkg: String?,
         expectedVc: Long,
+        userId: Int,
+        originatingUid: Int,
     ): Int? =
         when (backend) {
             Backend.SHIZUKU ->
                 ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY).use { pfd ->
                     val service = shizukuServiceManager.getService() ?: return@use null
-                    service.installPackage(pfd, file.length(), installerAttribution)
+                    service.installPackage(
+                        pfd,
+                        file.length(),
+                        expectedPkg,
+                        installerAttribution,
+                        userId,
+                        originatingUid,
+                    )
                 }
             Backend.DHIZUKU ->
                 ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY).use { pfd ->
                     val service = dhizukuServiceManager.getService() ?: return@use null
-                    service.installPackage(pfd, file.length(), expectedPkg, expectedVc, installerAttribution)
+                    service.installPackage(
+                        pfd,
+                        file.length(),
+                        expectedPkg,
+                        expectedVc,
+                        installerAttribution,
+                        userId,
+                        originatingUid,
+                    )
                 }
             Backend.ROOT ->
-
-                rootServiceManager.installPackage(file, installerAttribution)
+                rootServiceManager.installPackage(
+                    apkFile = file,
+                    installerPackageName = installerAttribution,
+                    userId = userId,
+                )
             Backend.DEFAULT -> null
         }
 
-    private fun readApkIdentity(filePath: String): Pair<String?, Long> {
-        val info = try {
-            androidContext.packageManager.getPackageArchiveInfo(filePath, 0)
-        } catch (e: Exception) {
-            Logger.w(TAG) { "getPackageArchiveInfo($filePath) failed: ${e.message}" }
-            null
-        } ?: return null to -1L
-        val versionCode = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
-            info.longVersionCode
-        } else {
-            @Suppress("DEPRECATION")
-            info.versionCode.toLong()
-        }
-        return info.packageName to versionCode
-    }
-
     private suspend fun silentUninstall(packageName: String, backend: Backend) {
+        val userId = PackageSessionInstaller.appUserId()
         try {
             val result = when (backend) {
                 Backend.SHIZUKU -> {
                     val service = shizukuServiceManager.getService()
-                    service?.uninstallPackage(packageName)
+                    service?.uninstallPackage(packageName, userId)
                 }
                 Backend.DHIZUKU -> {
                     val service = dhizukuServiceManager.getService()
-                    service?.uninstallPackage(packageName)
+                    service?.uninstallPackage(packageName, userId)
                 }
-                Backend.ROOT -> rootServiceManager.uninstallPackage(packageName)
+                Backend.ROOT -> rootServiceManager.uninstallPackage(packageName, userId)
                 Backend.DEFAULT -> null
             }
-            if (result == null || result != 0) {
+            if (result == null || result != PackageSessionInstaller.STATUS_SUCCESS) {
                 Logger.w(TAG) { "$backend uninstall failed (result=$result), falling back" }
                 androidInstaller.uninstall(packageName)
             }
@@ -247,7 +274,6 @@ class SilentInstallerDispatcher(
             if (dhizukuServiceManager.status.value == DhizukuStatus.READY) Backend.DHIZUKU else Backend.DEFAULT
         }
         InstallerType.ROOT -> {
-
             if (rootServiceManager.status.value != RootStatus.READY) {
                 rootServiceManager.refreshStatus()
             }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/root/RootServiceManager.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/root/RootServiceManager.kt
@@ -62,6 +62,7 @@ class RootServiceManager(
     suspend fun installPackage(
         apkFile: File,
         installerPackageName: String?,
+        userId: Int,
     ): Int? = withContext(Dispatchers.IO) {
         configureDefaultShell()
         if (!isRootGranted()) {
@@ -79,6 +80,7 @@ class RootServiceManager(
         val tmpPath = "/data/local/tmp/ghs_${System.currentTimeMillis()}_${(0..Int.MAX_VALUE).random()}.apk"
         val srcPath = shellQuote(apkFile.absolutePath)
         val tmpPathQuoted = shellQuote(tmpPath)
+        val safeUserId = userId.coerceAtLeast(0)
 
         try {
             val copyRes = Shell.cmd("cp $srcPath $tmpPathQuoted && chmod 644 $tmpPathQuoted").exec()
@@ -90,7 +92,7 @@ class RootServiceManager(
             }
 
             val command = buildString {
-                append("pm install ")
+                append("pm install --user ").append(safeUserId).append(' ')
                 if (safeInstaller != null) append("-i ").append(safeInstaller).append(' ')
                 append("-r ")
                 append(tmpPathQuoted)
@@ -111,7 +113,10 @@ class RootServiceManager(
         }
     }
 
-    suspend fun uninstallPackage(packageName: String): Int? = withContext(Dispatchers.IO) {
+    suspend fun uninstallPackage(
+        packageName: String,
+        userId: Int,
+    ): Int? = withContext(Dispatchers.IO) {
         configureDefaultShell()
         if (!isRootGranted()) {
             Logger.w(TAG) { "uninstallPackage() — root not granted, aborting" }
@@ -123,9 +128,10 @@ class RootServiceManager(
             }
             return@withContext STATUS_FAILURE
         }
-        val result = Shell.cmd("pm uninstall $packageName").exec()
+        val safeUserId = userId.coerceAtLeast(0)
+        val result = Shell.cmd("pm uninstall --user $safeUserId $packageName").exec()
         val stdout = result.out.joinToString("\n").trim()
-        Logger.d(TAG) { "uninstallPackage($packageName) — exit=${result.code} stdout='$stdout'" }
+        Logger.d(TAG) { "uninstallPackage($packageName, $safeUserId) — exit=${result.code} stdout='$stdout'" }
         if (result.isSuccess && stdout.contains("Success")) STATUS_SUCCESS else STATUS_FAILURE
     }
 

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/shizuku/ShizukuInstallerServiceImpl.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/shizuku/ShizukuInstallerServiceImpl.kt
@@ -1,133 +1,70 @@
 package zed.rainxch.core.data.services.shizuku
 
 import android.os.ParcelFileDescriptor
-import java.io.BufferedReader
-import java.io.InputStreamReader
-import java.util.concurrent.TimeUnit
+import zed.rainxch.core.data.services.installer.PackageSessionInstaller
 
 class ShizukuInstallerServiceImpl() : IShizukuInstallerService.Stub() {
 
     companion object {
         private const val TAG = "ShizukuService"
-
-        private const val STATUS_SUCCESS = 0
-        private const val STATUS_FAILURE = -1
-        private const val INSTALL_TIMEOUT_SECONDS = 120L
-        private const val UNINSTALL_TIMEOUT_SECONDS = 30L
-
         private fun log(msg: String) = android.util.Log.d(TAG, msg)
-        private fun logW(msg: String) = android.util.Log.w(TAG, msg)
         private fun logE(msg: String, e: Throwable? = null) = android.util.Log.e(TAG, msg, e)
     }
 
     override fun installPackage(
         pfd: ParcelFileDescriptor,
         fileSize: Long,
+        packageName: String?,
         installerPackageName: String?,
+        userId: Int,
+        originatingUid: Int,
     ): Int {
-        log("installPackage() called — fileSize=$fileSize, installer=$installerPackageName")
-        log("Process UID: ${android.os.Process.myUid()}, PID: ${android.os.Process.myPid()}")
-
+        log("installPackage() fileSize=$fileSize pkg=$packageName userId=$userId installer=$installerPackageName")
+        val ctx = PackageSessionInstaller.currentApplicationOrNull() ?: run {
+            logE("currentApplication() returned null")
+            return PackageSessionInstaller.STATUS_FAILURE
+        }
         return try {
-            val safeInstaller = installerPackageName?.takeIf { it.isNotBlank() }
-            val command = if (safeInstaller != null) {
-                arrayOf("pm", "install", "-i", safeInstaller, "-S", fileSize.toString())
-            } else {
-                arrayOf("pm", "install", "-S", fileSize.toString())
-            }
-            log("Executing: ${command.joinToString(" ")}")
-
-            val process = Runtime.getRuntime().exec(command)
-
-            val writeThread = Thread {
-                try {
-                    ParcelFileDescriptor.AutoCloseInputStream(pfd).use { input ->
-                        process.outputStream.use { output ->
-                            val buffer = ByteArray(65536)
-                            var bytesWritten = 0L
-                            var read: Int
-                            while (input.read(buffer).also { read = it } != -1) {
-                                output.write(buffer, 0, read)
-                                bytesWritten += read
-                            }
-                            output.flush()
-                            log("APK piped to pm stdin: $bytesWritten bytes (expected: $fileSize)")
-                        }
-                    }
-                } catch (e: Exception) {
-                    logE("Error piping APK to pm stdin", e)
-                }
-            }
-            writeThread.start()
-
-            val stdout = BufferedReader(InputStreamReader(process.inputStream)).readText().trim()
-            val stderr = BufferedReader(InputStreamReader(process.errorStream)).readText().trim()
-
-            writeThread.join(INSTALL_TIMEOUT_SECONDS * 1000)
-            if (writeThread.isAlive) {
-                logE("Write thread timed out after ${INSTALL_TIMEOUT_SECONDS}s, aborting install")
-                writeThread.interrupt()
-                process.destroyForcibly()
-                return STATUS_FAILURE
-            }
-
-            val finished = process.waitFor(INSTALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            if (!finished) {
-                logE("pm install timed out after ${INSTALL_TIMEOUT_SECONDS}s, aborting")
-                process.destroyForcibly()
-                return STATUS_FAILURE
-            }
-
-            val exitCode = process.exitValue()
-            log("pm install — exitCode=$exitCode, stdout='$stdout', stderr='$stderr'")
-
-            if (exitCode == 0 && stdout.contains("Success")) {
-                log("Install SUCCESS")
-                STATUS_SUCCESS
-            } else {
-                logE("Install FAILED — exitCode=$exitCode, stdout='$stdout', stderr='$stderr'")
-                STATUS_FAILURE
-            }
+            PackageSessionInstaller.installFromPfd(
+                context = ctx,
+                pfd = pfd,
+                fileSize = fileSize,
+                packageName = packageName,
+                expectedVersionCode = -1L,
+                installerPackageName = installerPackageName,
+                callerPackageName = ctx.packageName,
+                userId = userId,
+                originatingUid = originatingUid,
+                privileged = true,
+            )
         } catch (e: Exception) {
             logE("installPackage() exception", e)
-            STATUS_FAILURE
+            PackageSessionInstaller.STATUS_FAILURE
         }
     }
 
-    override fun uninstallPackage(packageName: String): Int {
-        log("uninstallPackage() called for: $packageName")
+    override fun uninstallPackage(packageName: String, userId: Int): Int {
+        log("uninstallPackage() pkg=$packageName userId=$userId")
+        val ctx = PackageSessionInstaller.currentApplicationOrNull() ?: run {
+            logE("currentApplication() returned null")
+            return PackageSessionInstaller.STATUS_FAILURE
+        }
         return try {
-            val command = arrayOf("pm", "uninstall", packageName)
-            log("Executing: ${command.joinToString(" ")}")
-
-            val process = Runtime.getRuntime().exec(command)
-            val stdout = BufferedReader(InputStreamReader(process.inputStream)).readText().trim()
-            val stderr = BufferedReader(InputStreamReader(process.errorStream)).readText().trim()
-
-            val finished = process.waitFor(UNINSTALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            if (!finished) {
-                logE("pm uninstall timed out after ${UNINSTALL_TIMEOUT_SECONDS}s, aborting")
-                process.destroyForcibly()
-                return STATUS_FAILURE
-            }
-
-            val exitCode = process.exitValue()
-            log("pm uninstall — exitCode=$exitCode, stdout='$stdout', stderr='$stderr'")
-
-            if (exitCode == 0 && stdout.contains("Success")) {
-                log("Uninstall SUCCESS")
-                STATUS_SUCCESS
-            } else {
-                logE("Uninstall FAILED — exitCode=$exitCode, stdout='$stdout', stderr='$stderr'")
-                STATUS_FAILURE
-            }
+            PackageSessionInstaller.uninstall(
+                context = ctx,
+                packageName = packageName,
+                userId = userId,
+                privileged = true,
+                callerPackageName = ctx.packageName,
+            )
         } catch (e: Exception) {
             logE("uninstallPackage() exception", e)
-            STATUS_FAILURE
+            PackageSessionInstaller.STATUS_FAILURE
         }
     }
 
     override fun destroy() {
         log("destroy() — service being unbound")
+        System.exit(0)
     }
 }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/shizuku/ShizukuServiceManager.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/shizuku/ShizukuServiceManager.kt
@@ -160,7 +160,7 @@ class ShizukuServiceManager(
                             .UserServiceArgs(componentName)
                             .daemon(false)
                             .processNameSuffix("installer")
-                            .version(1)
+                            .version(2)
 
                     val connection =
                         object : ServiceConnection {

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/services/DefaultDownloadOrchestrator.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/services/DefaultDownloadOrchestrator.kt
@@ -201,7 +201,7 @@ class DefaultDownloadOrchestrator(
                 runCatching { java.io.File(filePath).delete() }
                 markFailed(
                     spec.packageName,
-                    "Checksum mismatch — file may have been tampered with",
+                    "Checksum mismatch � file may have been tampered with",
                 )
                 return
             }
@@ -264,6 +264,7 @@ class DefaultDownloadOrchestrator(
                 }
 
                 InstallOutcome.DELEGATED_TO_SYSTEM -> {
+                    systemInstallSerializer.markCompleted(spec.packageName)
                     Logger.i {
                         "Orchestrator: AlwaysInstall path returned DELEGATED_TO_SYSTEM " +
                             "for ${spec.packageName}; Completed-with-pending so DB row stays pending"
@@ -455,6 +456,9 @@ class DefaultDownloadOrchestrator(
             systemInstallSerializer.awaitFreeAndMarkPending(packageName)
             val outcome = installer.install(filePath, ext)
             delegated = outcome == InstallOutcome.DELEGATED_TO_SYSTEM
+            if (delegated) {
+                systemInstallSerializer.markCompleted(packageName)
+            }
             if (outcome == InstallOutcome.COMPLETED) {
                 systemInstallSerializer.markCompleted(packageName)
                 try {

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
@@ -1284,6 +1284,7 @@ class AppsViewModel(
                     try {
                         systemInstallSerializer.awaitFreeAndMarkPending(app.packageName)
                         installer.install(filePath, ext)
+                        systemInstallSerializer.markCompleted(app.packageName)
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Exception) {

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -1513,6 +1513,9 @@ class DetailsViewModel(
                     try {
                         installer.install(warning.pendingFilePath, ext)
                     } catch (e: CancellationException) {
+                        if (gatePackageName != null) {
+                            systemInstallSerializer.markCompleted(gatePackageName)
+                        }
                         throw e
                     } catch (e: Throwable) {
                         if (gatePackageName != null) {
@@ -1520,6 +1523,9 @@ class DetailsViewModel(
                         }
                         throw e
                     }
+                if (gatePackageName != null) {
+                    systemInstallSerializer.markCompleted(gatePackageName)
+                }
 
                 if (platform == Platform.ANDROID) {
                     saveInstalledAppToDatabase(
@@ -2018,6 +2024,9 @@ class DetailsViewModel(
             try {
                 installer.install(filePath, ext)
             } catch (e: CancellationException) {
+                if (gatePackageName != null) {
+                    systemInstallSerializer.markCompleted(gatePackageName)
+                }
                 throw e
             } catch (e: Throwable) {
                 if (gatePackageName != null) {
@@ -2025,6 +2034,9 @@ class DetailsViewModel(
                 }
                 throw e
             }
+        if (gatePackageName != null) {
+            systemInstallSerializer.markCompleted(gatePackageName)
+        }
 
         launchAttestationCheck(filePath)
 


### PR DESCRIPTION
## Summary

- Silent Root/Shizuku/Dhizuku installs now target the current user only, so they no longer leak into work profile, Private Space, or clones 
- #718 
- #887

## Test plan

* [x] Root / Shizuku: installs only on the current user
* [ ] Dhizuku: not tested, as I’m currently unable to activate Dhizuku on my device
