### PR TITLE
fix: display release and advisory dates in the device timezone

### DIFF
--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/VersionPicker.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/VersionPicker.kt
@@ -40,6 +40,7 @@ import zed.rainxch.core.presentation.components.overlays.KomiSheetPlacement
 import zed.rainxch.core.presentation.components.text.KomiText
 import zed.rainxch.core.presentation.components.text.KomiTextRole
 import zed.rainxch.core.presentation.locals.LocalPersonality
+import zed.rainxch.core.presentation.utils.formatIsoDate
 import zed.rainxch.details.presentation.DetailsAction
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.latest_badge
@@ -251,7 +252,8 @@ private fun VersionListItem(
                 }
             }
             KomiText(
-                text = release.publishedAt.take(10),
+                text = formatIsoDate(release.publishedAt)
+                    ?: release.publishedAt.take(10),
                 role = KomiTextRole.Label,
                 fontSize = 12.sp,
                 fontWeight = FontWeight.Medium,

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/WhatsNew.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/WhatsNew.kt
@@ -49,6 +49,7 @@ import zed.rainxch.core.presentation.components.markdown.rememberMarkdownTypogra
 import zed.rainxch.core.presentation.components.text.KomiText
 import zed.rainxch.core.presentation.components.text.KomiTextRole
 import zed.rainxch.core.presentation.locals.LocalPersonality
+import zed.rainxch.core.presentation.utils.formatIsoDate
 import zed.rainxch.githubstore.core.presentation.res.*
 
 fun LazyListScope.whatsNew(
@@ -104,7 +105,8 @@ fun LazyListScope.whatsNew(
                 uppercase = false,
             )
             KomiText(
-                text = release.publishedAt.take(10),
+                text = formatIsoDate(release.publishedAt)
+                    ?: release.publishedAt.take(10),
                 role = KomiTextRole.Label,
                 fontSize = 12.sp,
                 color = colors.onSurfaceVariant,

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/whatsnew/DetailsWhatsNewViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/whatsnew/DetailsWhatsNewViewModel.kt
@@ -14,6 +14,7 @@ import zed.rainxch.details.domain.repository.TranslationRepository
 import zed.rainxch.details.presentation.model.SupportedLanguages
 import zed.rainxch.details.presentation.model.TranslationState
 import zed.rainxch.details.presentation.model.WhatsNewReleaseUi
+import zed.rainxch.core.presentation.utils.formatIsoDate
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.failed_to_load
 import zed.rainxch.githubstore.core.presentation.res.no_release_notes
@@ -168,7 +169,8 @@ class DetailsWhatsNewViewModel(
             WhatsNewReleaseUi(
                 id = release.id,
                 tagName = release.tagName,
-                publishedDate = release.publishedAt.take(10),
+                publishedDate = formatIsoDate(release.publishedAt)
+                    ?: release.publishedAt.take(10),
                 body = body,
             )
         }.toImmutableList()

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/whatsnew/DetailsWhatsNewViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/whatsnew/DetailsWhatsNewViewModel.kt
@@ -11,10 +11,10 @@ import org.jetbrains.compose.resources.getString
 import zed.rainxch.core.domain.model.account.github.GithubRelease
 import zed.rainxch.details.domain.repository.DetailsRepository
 import zed.rainxch.details.domain.repository.TranslationRepository
+import zed.rainxch.core.presentation.utils.formatIsoDate
 import zed.rainxch.details.presentation.model.SupportedLanguages
 import zed.rainxch.details.presentation.model.TranslationState
 import zed.rainxch.details.presentation.model.WhatsNewReleaseUi
-import zed.rainxch.core.presentation.utils.formatIsoDate
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.failed_to_load
 import zed.rainxch.githubstore.core.presentation.res.no_release_notes

--- a/feature/repo-pages/presentation/src/commonMain/kotlin/zed/rainxch/repopages/presentation/security/SecurityRoot.kt
+++ b/feature/repo-pages/presentation/src/commonMain/kotlin/zed/rainxch/repopages/presentation/security/SecurityRoot.kt
@@ -25,6 +25,7 @@ import zed.rainxch.core.presentation.components.text.KomiText
 import zed.rainxch.core.presentation.components.text.KomiTextRole
 import zed.rainxch.core.presentation.locals.LocalPersonality
 import zed.rainxch.core.presentation.locals.LocalStatusColors
+import zed.rainxch.core.presentation.utils.formatIsoDate
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.repo_pages_security_advisories_header
 import zed.rainxch.githubstore.core.presentation.res.repo_pages_security_no_advisories
@@ -183,7 +184,7 @@ private fun AdvisoryCard(advisory: SecurityAdvisory) {
                     advisory.cveId?.let { append(it) }
                     advisory.publishedAt?.let {
                         if (isNotEmpty()) append(" · ")
-                        append(it.take(10))
+                        append(formatIsoDate(it) ?: it.take(10))
                     }
                 }
                 if (meta.isNotEmpty()) {


### PR DESCRIPTION
## Problem

Release and advisory dates in the UI are rendered by slicing the raw ISO string (`publishedAt.take(10)`), which always shows the **UTC** calendar date regardless of the device timezone.

Concrete effect for UTC+8 users: a release published at `2026-09-02T18:56:02Z` (03:56 next day local) still displays as `2026-09-02` on a date that is already the 3rd locally — freshly rebuilt nightlies look like "no update today" even though the store correctly detected and reported them (the detection layer compares the raw UTC strings, so this is display-only).

## Fix

Reuse the existing `formatIsoDate()` helper in `core/presentation/utils/TimeFormatters.kt`, which parses the ISO timestamp leniently and converts it via `TimeZone.currentSystemDefault()`. Applied at all four display sites:

- Details page What's New section (`WhatsNew.kt`)
- Version picker (`VersionPicker.kt`)
- What's New history (`DetailsWhatsNewViewModel.kt`)
- Security advisories list (`SecurityRoot.kt`)

Unparseable values fall back to the previous truncation, so nothing regresses on odd timestamp formats.

## Validation

- `:feature:details:presentation:compileDebugKotlinAndroid`
- `:feature:repo-pages:presentation:compileDebugKotlinAndroid`
- `:composeApp:assembleDebug`

No schema, detection-logic, or persisted-data changes — display layer only.
