### PR TITLE
fix: load persisted appearance before first frame; splash covers the load

### DIFF
--- a/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/MainActivity.kt
@@ -19,10 +19,8 @@ import androidx.lifecycle.repeatOnLifecycle
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.getViewModel
 import zed.rainxch.core.data.services.LocalizationManager
@@ -31,6 +29,7 @@ import zed.rainxch.core.domain.helpers.ShareManager
 import zed.rainxch.core.domain.repository.TweaksRepository
 import zed.rainxch.core.domain.use_cases.SyncInstalledAppsUseCase
 import zed.rainxch.githubstore.app.deeplink.DeepLinkParser
+import zed.rainxch.githubstore.utils.readStartupPreference
 import zed.rainxch.githubstore.utils.updateSystemBars
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -60,13 +59,11 @@ class MainActivity : ComponentActivity() {
 
         runBlocking {
             val tag =
-                try {
-                    withTimeoutOrNull(LANGUAGE_PREF_READ_TIMEOUT_MS.milliseconds) {
-                        tweaksRepository.getAppLanguage().first()
-                    }
-                } catch (_: Exception) {
-                    null
-                }
+                readStartupPreference(
+                    label = "appLanguage",
+                    timeout = LANGUAGE_PREF_READ_TIMEOUT_MS.milliseconds,
+                    flow = tweaksRepository.getAppLanguage(),
+                )
             localizationManager.setActiveLanguageTag(tag)
         }
 

--- a/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/MainActivity.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.android.ext.android.inject
+import org.koin.androidx.viewmodel.ext.android.getViewModel
 import zed.rainxch.core.data.services.LocalizationManager
 import zed.rainxch.core.data.utils.AndroidShareManager
 import zed.rainxch.core.domain.helpers.ShareManager
@@ -38,10 +39,12 @@ private const val LANGUAGE_PREF_READ_TIMEOUT_MS = 2000L
 class MainActivity : ComponentActivity() {
     private var deepLinkUri by mutableStateOf<String?>(null)
 
-    // Flipped by Compose when AppNavigation's first real frame has drawn.
-    // The splash holds until this — data-ready alone still shows a
-    // placeholder frame while Compose composes the actual UI.
-    private var contentDrawn by mutableStateOf(false)
+    // Mirror of MainViewModel.appearanceLoaded, collected here so the splash
+    // hold reads the SAME single source of truth the Compose gate uses.
+    // While true, the keep-on-screen condition cancels every draw request —
+    // the placeholder frame is never rendered, so the user goes
+    // splash -> their real theme with zero intermediate frames.
+    private var appearanceLoaded = false
     private val shareManager: ShareManager by inject()
     private val tweaksRepository: TweaksRepository by inject()
     private val localizationManager: LocalizationManager by inject()
@@ -50,9 +53,10 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splash = installSplashScreen()
-        // The splash covers preference load AND the first real content frame;
-        // see contentDrawn.
-        splash.setKeepOnScreenCondition { !contentDrawn }
+        // Hold while the persisted appearance preferences are still loading.
+        // While held, draw requests are cancelled so no placeholder frame is
+        // ever rendered; the first frame released is the real themed UI.
+        splash.setKeepOnScreenCondition { !appearanceLoaded }
         enableEdgeToEdge()
 
         (shareManager as? AndroidShareManager)?.registerActivityResultLauncher(this)
@@ -82,6 +86,19 @@ class MainActivity : ComponentActivity() {
                         localizationManager.setActiveLanguageTag(newTag)
                         recreate()
                     }
+            }
+        }
+
+        // Mirror the MainViewModel appearance gate into this activity so the
+        // splash hold reads the same value the Compose gate does. MainViewModel
+        // is a Koin single-activity-scoped view model resolved with the same
+        // factory inside setContent's koinViewModel().
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                val viewModel = getViewModel<MainViewModel>()
+                viewModel.state.collect { state ->
+                    appearanceLoaded = state.appearanceLoaded
+                }
             }
         }
 

--- a/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/MainActivity.kt
@@ -18,15 +18,10 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.android.ext.android.inject
 import zed.rainxch.core.data.services.LocalizationManager
@@ -42,6 +37,11 @@ private const val LANGUAGE_PREF_READ_TIMEOUT_MS = 2000L
 
 class MainActivity : ComponentActivity() {
     private var deepLinkUri by mutableStateOf<String?>(null)
+
+    // Flipped by Compose when AppNavigation's first real frame has drawn.
+    // The splash holds until this — data-ready alone still shows a
+    // placeholder frame while Compose composes the actual UI.
+    private var contentDrawn by mutableStateOf(false)
     private val shareManager: ShareManager by inject()
     private val tweaksRepository: TweaksRepository by inject()
     private val localizationManager: LocalizationManager by inject()
@@ -50,33 +50,9 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splash = installSplashScreen()
-        // Keep the system splash on screen until the persisted appearance
-        // preferences have loaded, so the first Compose frame the user sees
-        // is already in their theme instead of a themed placeholder frame.
-        var appearanceReady = false
-        splash.setKeepOnScreenCondition { !appearanceReady }
-        lifecycleScope.launch {
-            withContext(kotlinx.coroutines.Dispatchers.IO) {
-                try {
-                    coroutineScope {
-                        listOf(
-                            async { tweaksRepository.getPersonality().first() },
-                            async { tweaksRepository.getThemeColor().first() },
-                            async { tweaksRepository.getAmoledTheme().first() },
-                            async { tweaksRepository.getIsDarkTheme().first() },
-                            async { tweaksRepository.getAccentId().first() },
-                            async { tweaksRepository.getMangaPaper().first() },
-                            async { tweaksRepository.getScrollbarEnabled().first() },
-                            async { tweaksRepository.getContentWidth().first() },
-                            async { tweaksRepository.getAppLanguage().first() },
-                        ).awaitAll()
-                    }
-                } catch (e: Exception) {
-                    Logger.w(e) { "appearance pre-read failed; releasing splash anyway" }
-                }
-            }
-            appearanceReady = true
-        }
+        // The splash covers preference load AND the first real content frame;
+        // see contentDrawn.
+        splash.setKeepOnScreenCondition { !contentDrawn }
         enableEdgeToEdge()
 
         (shareManager as? AndroidShareManager)?.registerActivityResultLauncher(this)

--- a/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/MainActivity.kt
@@ -39,12 +39,6 @@ private const val LANGUAGE_PREF_READ_TIMEOUT_MS = 2000L
 class MainActivity : ComponentActivity() {
     private var deepLinkUri by mutableStateOf<String?>(null)
 
-    // Mirror of MainViewModel.appearanceLoaded, collected here so the splash
-    // hold reads the SAME single source of truth the Compose gate uses.
-    // While true, the keep-on-screen condition cancels every draw request —
-    // the placeholder frame is never rendered, so the user goes
-    // splash -> their real theme with zero intermediate frames.
-    private var appearanceLoaded = false
     private val shareManager: ShareManager by inject()
     private val tweaksRepository: TweaksRepository by inject()
     private val localizationManager: LocalizationManager by inject()
@@ -53,10 +47,12 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splash = installSplashScreen()
-        // Hold while the persisted appearance preferences are still loading.
-        // While held, draw requests are cancelled so no placeholder frame is
-        // ever rendered; the first frame released is the real themed UI.
-        splash.setKeepOnScreenCondition { !appearanceLoaded }
+        // KeepOnScreenCondition is polled before each draw: while it returns
+        // true every draw request is cancelled, so the first frame the user
+        // ever sees is the real themed UI, never the unthemed placeholder.
+        // Same StateFlow the Compose gate in App() reads — single source.
+        val mainViewModel = getViewModel<MainViewModel>()
+        splash.setKeepOnScreenCondition { !mainViewModel.state.value.appearanceLoaded }
         enableEdgeToEdge()
 
         (shareManager as? AndroidShareManager)?.registerActivityResultLauncher(this)
@@ -86,19 +82,6 @@ class MainActivity : ComponentActivity() {
                         localizationManager.setActiveLanguageTag(newTag)
                         recreate()
                     }
-            }
-        }
-
-        // Mirror the MainViewModel appearance gate into this activity so the
-        // splash hold reads the same value the Compose gate does. MainViewModel
-        // is a Koin single-activity-scoped view model resolved with the same
-        // factory inside setContent's koinViewModel().
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                val viewModel = getViewModel<MainViewModel>()
-                viewModel.state.collect { state ->
-                    appearanceLoaded = state.appearanceLoaded
-                }
             }
         }
 

--- a/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/MainActivity.kt
@@ -18,10 +18,15 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.android.ext.android.inject
 import zed.rainxch.core.data.services.LocalizationManager
@@ -44,7 +49,34 @@ class MainActivity : ComponentActivity() {
     private val appScope: CoroutineScope by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        installSplashScreen()
+        val splash = installSplashScreen()
+        // Keep the system splash on screen until the persisted appearance
+        // preferences have loaded, so the first Compose frame the user sees
+        // is already in their theme instead of a themed placeholder frame.
+        var appearanceReady = false
+        splash.setKeepOnScreenCondition { !appearanceReady }
+        lifecycleScope.launch {
+            withContext(kotlinx.coroutines.Dispatchers.IO) {
+                try {
+                    coroutineScope {
+                        listOf(
+                            async { tweaksRepository.getPersonality().first() },
+                            async { tweaksRepository.getThemeColor().first() },
+                            async { tweaksRepository.getAmoledTheme().first() },
+                            async { tweaksRepository.getIsDarkTheme().first() },
+                            async { tweaksRepository.getAccentId().first() },
+                            async { tweaksRepository.getMangaPaper().first() },
+                            async { tweaksRepository.getScrollbarEnabled().first() },
+                            async { tweaksRepository.getContentWidth().first() },
+                            async { tweaksRepository.getAppLanguage().first() },
+                        ).awaitAll()
+                    }
+                } catch (e: Exception) {
+                    Logger.w(e) { "appearance pre-read failed; releasing splash anyway" }
+                }
+            }
+            appearanceReady = true
+        }
         enableEdgeToEdge()
 
         (shareManager as? AndroidShareManager)?.registerActivityResultLauncher(this)

--- a/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/MainActivity.kt
@@ -48,9 +48,10 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         val splash = installSplashScreen()
         // KeepOnScreenCondition is polled before each draw: while it returns
-        // true every draw request is cancelled, so the first frame the user
-        // ever sees is the real themed UI, never the unthemed placeholder.
-        // Same StateFlow the Compose gate in App() reads — single source.
+        // true every draw request is cancelled, so no placeholder frame is
+        // ever rendered. The frame released is the real themed UI; only on
+        // the rare watchdog timeout can it hold defaults briefly (see
+        // MainViewModel). Same StateFlow the Compose gate reads.
         val mainViewModel = getViewModel<MainViewModel>()
         splash.setKeepOnScreenCondition { !mainViewModel.state.value.appearanceLoaded }
         enableEdgeToEdge()

--- a/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/MainActivity.kt
@@ -53,7 +53,7 @@ class MainActivity : ComponentActivity() {
         // the rare watchdog timeout can it hold defaults briefly (see
         // MainViewModel). Same StateFlow the Compose gate reads.
         val mainViewModel = getViewModel<MainViewModel>()
-        splash.setKeepOnScreenCondition { !mainViewModel.state.value.appearanceLoaded }
+        splash.setKeepOnScreenCondition { !mainViewModel.state.value.isAppearanceLoaded }
         enableEdgeToEdge()
 
         (shareManager as? AndroidShareManager)?.registerActivityResultLauncher(this)

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
@@ -54,7 +54,7 @@ fun App(
     // deep-link effect navigates a NavHost that is only composed after this
     // gate, and the theme would be built from untrusted defaults. Android
     // covers the wait with the splash; desktop shows a plain window frame.
-    if (!mainState.appearanceLoaded) {
+    if (!mainState.isAppearanceLoaded) {
         Box(modifier = Modifier.fillMaxSize())
         return
     }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
@@ -116,14 +116,14 @@ fun App(
             navController = navController,
             isScrollbarEnabled = mainState.isScrollbarEnabled,
             contentWidth = mainState.contentWidth,
+            // First drawn frame of real content releases the splash (Android
+            // MainActivity observes contentDrawn). Desktop has no splash and
+            // simply ignores the flag.
             modifier =
                 Modifier.drawWithContent {
-                    if (mainState.appearanceLoaded && !contentDrawn) {
-                        // first real frame is about to hit the screen — release the splash
-                        drawContent()
+                    drawContent()
+                    if (!contentDrawn) {
                         contentDrawn = true
-                    } else {
-                        drawContent()
                     }
                 },
         )

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
@@ -1,6 +1,5 @@
 package zed.rainxch.githubstore
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -51,6 +50,15 @@ fun App(
             .build()
     }
 
+    // Nothing below may run before persisted appearance preferences load: the
+    // deep-link effect navigates a NavHost that is only composed after this
+    // gate, and the theme would be built from untrusted defaults. Android
+    // covers the wait with the splash; desktop shows a plain window frame.
+    if (!mainState.appearanceLoaded) {
+        Box(modifier = Modifier.fillMaxSize())
+        return
+    }
+
     val currentScreen = navController.currentBackStackEntryAsState().value.getCurrentScreen()
 
     HandleKeyboardEvents(navController)
@@ -90,19 +98,6 @@ fun App(
         }
 
     PersonalityTheme(personality, languageTag = mainState.appLanguageTag) {
-        if (!mainState.appearanceLoaded) {
-            // Persisted appearance preferences are still loading — hold the
-            // frame on the (already correct) theme background instead of
-            // rendering navigation with hardcoded default values.
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .background(personality.colors.background),
-            )
-            return@PersonalityTheme
-        }
-
         AppNavigation(
             navController = navController,
             isScrollbarEnabled = mainState.isScrollbarEnabled,

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
@@ -7,11 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithContent
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
@@ -45,11 +41,6 @@ fun App(
     val whatsNewViewModel: WhatsNewViewModel = koinViewModel()
 
     val mainState by mainViewModel.state.collectAsStateWithLifecycle()
-
-    // True once AppNavigation's first real frame has been drawn. The splash
-    // (Android) holds until this — data-ready alone still leaves a visible
-    // placeholder window while Compose composes the actual UI.
-    var contentDrawn by remember { androidx.compose.runtime.mutableStateOf(false) }
 
     val navController = rememberNavController()
 
@@ -116,16 +107,6 @@ fun App(
             navController = navController,
             isScrollbarEnabled = mainState.isScrollbarEnabled,
             contentWidth = mainState.contentWidth,
-            // First drawn frame of real content releases the splash (Android
-            // MainActivity observes contentDrawn). Desktop has no splash and
-            // simply ignores the flag.
-            modifier =
-                Modifier.drawWithContent {
-                    drawContent()
-                    if (!contentDrawn) {
-                        contentDrawn = true
-                    }
-                },
         )
 
         if (mainState.showRateLimitDialog && mainState.rateLimitInfo != null && !onAuthScreen) {

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
@@ -7,7 +7,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
@@ -41,6 +45,11 @@ fun App(
     val whatsNewViewModel: WhatsNewViewModel = koinViewModel()
 
     val mainState by mainViewModel.state.collectAsStateWithLifecycle()
+
+    // True once AppNavigation's first real frame has been drawn. The splash
+    // (Android) holds until this — data-ready alone still leaves a visible
+    // placeholder window while Compose composes the actual UI.
+    var contentDrawn by remember { androidx.compose.runtime.mutableStateOf(false) }
 
     val navController = rememberNavController()
 
@@ -107,6 +116,16 @@ fun App(
             navController = navController,
             isScrollbarEnabled = mainState.isScrollbarEnabled,
             contentWidth = mainState.contentWidth,
+            modifier =
+                Modifier.drawWithContent {
+                    if (mainState.appearanceLoaded && !contentDrawn) {
+                        // first real frame is about to hit the screen — release the splash
+                        drawContent()
+                        contentDrawn = true
+                    } else {
+                        drawContent()
+                    }
+                },
         )
 
         if (mainState.showRateLimitDialog && mainState.rateLimitInfo != null && !onAuthScreen) {

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
@@ -1,9 +1,13 @@
 package zed.rainxch.githubstore
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
@@ -86,6 +90,19 @@ fun App(
         }
 
     PersonalityTheme(personality, languageTag = mainState.appLanguageTag) {
+        if (!mainState.appearanceLoaded) {
+            // Persisted appearance preferences are still loading — hold the
+            // frame on the (already correct) theme background instead of
+            // rendering navigation with hardcoded default values.
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(personality.colors.background),
+            )
+            return@PersonalityTheme
+        }
+
         AppNavigation(
             navController = navController,
             isScrollbarEnabled = mainState.isScrollbarEnabled,

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainState.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainState.kt
@@ -25,5 +25,5 @@ data class MainState(
     val appLanguageTag: String? = null,
     // False until persisted appearance preferences have loaded (or the load
     // timed out). The first frame must not render before it flips.
-    val appearanceLoaded: Boolean = false,
+    val isAppearanceLoaded: Boolean = false,
 )

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainState.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainState.kt
@@ -23,11 +23,9 @@ data class MainState(
     val isScrollbarEnabled: Boolean = false,
     val contentWidth: ContentWidth = ContentWidth.COMPACT,
     val appLanguageTag: String? = null,
-    /**
-     * True once every persisted appearance preference has emitted its first
-     * value. The first frame is held until then so the UI never renders with
-     * the hardcoded defaults (MANGA personality, NORD theme) before the
-     * user's actual choices arrive from storage.
-     */
+    // Held false until every persisted appearance preference has emitted, so
+    // the first frame never renders the hardcoded defaults. Awaited in
+    // MainViewModel.init; getFontTheme is intentionally excluded (font does
+    // not affect the placeholder background).
     val appearanceLoaded: Boolean = false,
 )

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainState.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainState.kt
@@ -23,4 +23,11 @@ data class MainState(
     val isScrollbarEnabled: Boolean = false,
     val contentWidth: ContentWidth = ContentWidth.COMPACT,
     val appLanguageTag: String? = null,
+    /**
+     * True once every persisted appearance preference has emitted its first
+     * value. The first frame is held until then so the UI never renders with
+     * the hardcoded defaults (MANGA personality, NORD theme) before the
+     * user's actual choices arrive from storage.
+     */
+    val appearanceLoaded: Boolean = false,
 )

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainState.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainState.kt
@@ -23,9 +23,7 @@ data class MainState(
     val isScrollbarEnabled: Boolean = false,
     val contentWidth: ContentWidth = ContentWidth.COMPACT,
     val appLanguageTag: String? = null,
-    // Held false until every persisted appearance preference has emitted, so
-    // the first frame never renders the hardcoded defaults. Awaited in
-    // MainViewModel.init; getFontTheme is intentionally excluded (font does
-    // not affect the placeholder background).
+    // False until persisted appearance preferences have loaded (or the load
+    // timed out). The first frame must not render before it flips.
     val appearanceLoaded: Boolean = false,
 )

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainViewModel.kt
@@ -2,6 +2,7 @@ package zed.rainxch.githubstore
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -90,11 +91,12 @@ class MainViewModel(
                     Appearance(personality, accent, paper, amoled, isDark)
                 }.collect { snapshot ->
                     _state.update { it.withAppearance(snapshot).copy(isAppearanceLoaded = true) }
-                    firstEmitted.complete(Unit)
+                    if (!firstEmitted.isCompleted) firstEmitted.complete(Unit)
                 }
             } catch (e: CancellationException) {
                 throw e
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                Logger.w(e) { "Appearance preference stream failed, releasing gate on defaults" }
                 _state.update { it.copy(isAppearanceLoaded = true) }
             }
         }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainViewModel.kt
@@ -65,13 +65,19 @@ class MainViewModel(
 
         // Sole writer of the gated appearance fields: combine emits only after
         // all five sources have a first value, so fields and flag land in one
-        // update. The watchdog releases the gate on defaults if that emission
-        // never arrives, mirroring the guarded language read in MainActivity.
+        // update. If that emission never arrives within the timeout — or the
+        // collector throws — the watchdog releases the gate on defaults so
+        // the splash can never be held indefinitely.
         viewModelScope.launch {
             val firstEmitted = CompletableDeferred<Unit>()
             launch {
-                withTimeoutOrNull(APPEARANCE_LOAD_TIMEOUT_MS.milliseconds) { firstEmitted.await() }
-                _state.update { it.copy(appearanceLoaded = true) }
+                if (
+                    withTimeoutOrNull(APPEARANCE_LOAD_TIMEOUT_MS.milliseconds) {
+                        firstEmitted.await()
+                    } == null
+                ) {
+                    _state.update { it.copy(appearanceLoaded = true) }
+                }
             }
             try {
                 combine(

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainViewModel.kt
@@ -3,8 +3,12 @@ package zed.rainxch.githubstore
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import zed.rainxch.core.domain.repository.InstalledAppsRepository
@@ -108,6 +112,26 @@ class MainViewModel(
             tweaksRepository.getAppLanguage().collect { tag ->
                 _state.update { it.copy(appLanguageTag = tag) }
             }
+        }
+
+        // Hold the first frame until every persisted appearance preference has
+        // emitted its stored value, so the UI never flashes the hardcoded
+        // defaults (MANGA personality, NORD theme) on startup.
+        viewModelScope.launch {
+            coroutineScope {
+                listOf(
+                    async { tweaksRepository.getPersonality().first() },
+                    async { tweaksRepository.getThemeColor().first() },
+                    async { tweaksRepository.getAmoledTheme().first() },
+                    async { tweaksRepository.getIsDarkTheme().first() },
+                    async { tweaksRepository.getAccentId().first() },
+                    async { tweaksRepository.getMangaPaper().first() },
+                    async { tweaksRepository.getScrollbarEnabled().first() },
+                    async { tweaksRepository.getContentWidth().first() },
+                    async { tweaksRepository.getAppLanguage().first() },
+                ).awaitAll()
+            }
+            _state.update { it.copy(appearanceLoaded = true) }
         }
 
         viewModelScope.launch {

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainViewModel.kt
@@ -3,19 +3,22 @@ package zed.rainxch.githubstore
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import zed.rainxch.core.domain.model.appearance.AccentId
+import zed.rainxch.core.domain.model.appearance.AppPersonality
+import zed.rainxch.core.domain.model.appearance.MangaPaperId
 import zed.rainxch.core.domain.repository.InstalledAppsRepository
 import zed.rainxch.core.domain.repository.RateLimitRepository
 import zed.rainxch.core.domain.repository.TweaksRepository
 import zed.rainxch.core.domain.repository.UserSessionRepository
 import zed.rainxch.core.domain.use_cases.SyncInstalledAppsUseCase
+import kotlin.time.Duration.Companion.milliseconds
 
 class MainViewModel(
     private val tweaksRepository: TweaksRepository,
@@ -51,25 +54,6 @@ class MainViewModel(
         }
         viewModelScope.launch {
             tweaksRepository
-                .getAmoledTheme()
-                .collect { isAmoled ->
-                    _state.update {
-                        it.copy(isAmoledTheme = isAmoled)
-                    }
-                }
-        }
-        viewModelScope.launch {
-            tweaksRepository
-                .getIsDarkTheme()
-                .collect { isDarkTheme ->
-                    _state.update {
-                        it.copy(isDarkTheme = isDarkTheme)
-                    }
-                }
-        }
-
-        viewModelScope.launch {
-            tweaksRepository
                 .getFontTheme()
                 .collect { fontTheme ->
                     _state.update {
@@ -78,21 +62,37 @@ class MainViewModel(
                 }
         }
 
+        // Sole writer of the gated appearance fields. combine emits only after
+        // all five sources have their first value, so state and the gate flag
+        // land in one update. The timeout releases the gate on defaults if a
+        // source never emits (same guard as the language read in MainActivity).
         viewModelScope.launch {
-            tweaksRepository.getPersonality().collect { personality ->
-                _state.update { it.copy(personality = personality) }
+            val appearance =
+                combine(
+                    tweaksRepository.getPersonality(),
+                    tweaksRepository.getAccentId(),
+                    tweaksRepository.getMangaPaper(),
+                    tweaksRepository.getAmoledTheme(),
+                    tweaksRepository.getIsDarkTheme(),
+                ) { personality, accent, paper, amoled, isDark ->
+                    Appearance(personality, accent, paper, amoled, isDark)
+                }
+            val loaded =
+                try {
+                    withTimeoutOrNull(APPEARANCE_LOAD_TIMEOUT_MS.milliseconds) {
+                        appearance.first()
+                    }
+                } catch (_: Exception) {
+                    null
+                }
+            if (loaded != null) {
+                _state.update { it.withAppearance(loaded).copy(appearanceLoaded = true) }
+            } else {
+                _state.update { it.copy(appearanceLoaded = true) }
             }
-        }
 
-        viewModelScope.launch {
-            tweaksRepository.getAccentId().collect { accent ->
-                _state.update { it.copy(accent = accent) }
-            }
-        }
-
-        viewModelScope.launch {
-            tweaksRepository.getMangaPaper().collect { paper ->
-                _state.update { it.copy(mangaPaper = paper) }
+            appearance.collect { snapshot ->
+                _state.update { it.withAppearance(snapshot) }
             }
         }
 
@@ -112,26 +112,6 @@ class MainViewModel(
             tweaksRepository.getAppLanguage().collect { tag ->
                 _state.update { it.copy(appLanguageTag = tag) }
             }
-        }
-
-        // Hold the first frame until every persisted appearance preference has
-        // emitted its stored value, so the UI never flashes the hardcoded
-        // defaults (MANGA personality, NORD theme) on startup.
-        viewModelScope.launch {
-            coroutineScope {
-                listOf(
-                    async { tweaksRepository.getPersonality().first() },
-                    async { tweaksRepository.getThemeColor().first() },
-                    async { tweaksRepository.getAmoledTheme().first() },
-                    async { tweaksRepository.getIsDarkTheme().first() },
-                    async { tweaksRepository.getAccentId().first() },
-                    async { tweaksRepository.getMangaPaper().first() },
-                    async { tweaksRepository.getScrollbarEnabled().first() },
-                    async { tweaksRepository.getContentWidth().first() },
-                    async { tweaksRepository.getAppLanguage().first() },
-                ).awaitAll()
-            }
-            _state.update { it.copy(appearanceLoaded = true) }
         }
 
         viewModelScope.launch {
@@ -173,3 +153,22 @@ class MainViewModel(
         }
     }
 }
+
+private const val APPEARANCE_LOAD_TIMEOUT_MS = 2000L
+
+private data class Appearance(
+    val personality: AppPersonality,
+    val accent: AccentId,
+    val mangaPaper: MangaPaperId,
+    val isAmoledTheme: Boolean,
+    val isDarkTheme: Boolean?,
+)
+
+private fun MainState.withAppearance(snapshot: Appearance): MainState =
+    copy(
+        personality = snapshot.personality,
+        accent = snapshot.accent,
+        mangaPaper = snapshot.mangaPaper,
+        isAmoledTheme = snapshot.isAmoledTheme,
+        isDarkTheme = snapshot.isDarkTheme,
+    )

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainViewModel.kt
@@ -76,7 +76,7 @@ class MainViewModel(
                         firstEmitted.await()
                     } == null
                 ) {
-                    _state.update { it.copy(appearanceLoaded = true) }
+                    _state.update { it.copy(isAppearanceLoaded = true) }
                 }
             }
             try {
@@ -89,13 +89,13 @@ class MainViewModel(
                 ) { personality, accent, paper, amoled, isDark ->
                     Appearance(personality, accent, paper, amoled, isDark)
                 }.collect { snapshot ->
-                    _state.update { it.withAppearance(snapshot).copy(appearanceLoaded = true) }
+                    _state.update { it.withAppearance(snapshot).copy(isAppearanceLoaded = true) }
                     firstEmitted.complete(Unit)
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Exception) {
-                _state.update { it.copy(appearanceLoaded = true) }
+                _state.update { it.copy(isAppearanceLoaded = true) }
             }
         }
 

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainViewModel.kt
@@ -2,11 +2,12 @@ package zed.rainxch.githubstore
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -62,12 +63,17 @@ class MainViewModel(
                 }
         }
 
-        // Sole writer of the gated appearance fields. combine emits only after
-        // all five sources have their first value, so state and the gate flag
-        // land in one update. The timeout releases the gate on defaults if a
-        // source never emits (same guard as the language read in MainActivity).
+        // Sole writer of the gated appearance fields: combine emits only after
+        // all five sources have a first value, so fields and flag land in one
+        // update. The watchdog releases the gate on defaults if that emission
+        // never arrives, mirroring the guarded language read in MainActivity.
         viewModelScope.launch {
-            val appearance =
+            val firstEmitted = CompletableDeferred<Unit>()
+            launch {
+                withTimeoutOrNull(APPEARANCE_LOAD_TIMEOUT_MS.milliseconds) { firstEmitted.await() }
+                _state.update { it.copy(appearanceLoaded = true) }
+            }
+            try {
                 combine(
                     tweaksRepository.getPersonality(),
                     tweaksRepository.getAccentId(),
@@ -76,23 +82,14 @@ class MainViewModel(
                     tweaksRepository.getIsDarkTheme(),
                 ) { personality, accent, paper, amoled, isDark ->
                     Appearance(personality, accent, paper, amoled, isDark)
+                }.collect { snapshot ->
+                    _state.update { it.withAppearance(snapshot).copy(appearanceLoaded = true) }
+                    firstEmitted.complete(Unit)
                 }
-            val loaded =
-                try {
-                    withTimeoutOrNull(APPEARANCE_LOAD_TIMEOUT_MS.milliseconds) {
-                        appearance.first()
-                    }
-                } catch (_: Exception) {
-                    null
-                }
-            if (loaded != null) {
-                _state.update { it.withAppearance(loaded).copy(appearanceLoaded = true) }
-            } else {
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
                 _state.update { it.copy(appearanceLoaded = true) }
-            }
-
-            appearance.collect { snapshot ->
-                _state.update { it.withAppearance(snapshot) }
             }
         }
 

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
@@ -91,7 +91,6 @@ fun AppNavigation(
     navController: NavHostController,
     isScrollbarEnabled: Boolean,
     contentWidth: ContentWidth,
-    modifier: Modifier = Modifier,
 ) {
     val appsViewModel = koinViewModel<AppsViewModel>()
     val appsState by appsViewModel.state.collectAsStateWithLifecycle()
@@ -104,7 +103,7 @@ fun AppNavigation(
         LocalScrollbarEnabled provides isScrollbarEnabled,
         LocalContentWidth provides contentWidth,
     ) {
-        BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
             val rail = maxWidth < 1140.dp
             Row(modifier = Modifier.fillMaxSize()) {
                 val desktopDrawerCurrent =

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
@@ -91,6 +91,7 @@ fun AppNavigation(
     navController: NavHostController,
     isScrollbarEnabled: Boolean,
     contentWidth: ContentWidth,
+    modifier: Modifier = Modifier,
 ) {
     val appsViewModel = koinViewModel<AppsViewModel>()
     val appsState by appsViewModel.state.collectAsStateWithLifecycle()
@@ -103,7 +104,7 @@ fun AppNavigation(
         LocalScrollbarEnabled provides isScrollbarEnabled,
         LocalContentWidth provides contentWidth,
     ) {
-        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        BoxWithConstraints(modifier = modifier.fillMaxSize()) {
             val rail = maxWidth < 1140.dp
             Row(modifier = Modifier.fillMaxSize()) {
                 val desktopDrawerCurrent =

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/utils/StartupPreferences.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/utils/StartupPreferences.kt
@@ -1,0 +1,24 @@
+package zed.rainxch.githubstore.utils
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration
+
+suspend fun <T> readStartupPreference(
+    label: String,
+    timeout: Duration,
+    flow: Flow<T>,
+): T? =
+    // Startup paths must never hang or crash on a wedged DataStore — they
+    // need a value now, so every failure mode (timeout, error) degrades to
+    // null. Errors are logged: silent degradation would hide real breakage.
+    try {
+        withTimeoutOrNull(timeout) { flow.first() }
+    } catch (e: kotlinx.coroutines.CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Logger.w(e) { "Startup preference '$label' failed, degrading to null" }
+        null
+    }

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
@@ -21,10 +21,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeoutOrNull
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.core.context.GlobalContext
@@ -58,6 +56,7 @@ import zed.rainxch.githubstore.desktop.WindowStateStore
 import zed.rainxch.githubstore.desktop.applyMacosWindowAppearance
 import zed.rainxch.githubstore.desktop.applyWindowsImmersiveDarkMode
 import zed.rainxch.githubstore.desktop.installMacosSystemAppearance
+import zed.rainxch.githubstore.utils.readStartupPreference
 import java.awt.Desktop
 import java.net.URI
 import java.security.Security
@@ -92,13 +91,11 @@ fun main(args: Array<String>) {
         val tweaksRepo = koin.get<TweaksRepository>()
         val localization = koin.get<LocalizationManager>()
         val tag =
-            try {
-                withTimeoutOrNull(LANGUAGE_PREF_READ_TIMEOUT_MS.milliseconds) {
-                    tweaksRepo.getAppLanguage().first()
-                }
-            } catch (_: Exception) {
-                null
-            }
+            readStartupPreference(
+                label = "appLanguage",
+                timeout = LANGUAGE_PREF_READ_TIMEOUT_MS.milliseconds,
+                flow = tweaksRepo.getAppLanguage(),
+            )
         localization.setActiveLanguageTag(tag)
     }
 


### PR DESCRIPTION
# fix: load persisted appearance before first frame; splash covers the load

## Problem

On every launch the app renders its first frames from the hardcoded `MainState` defaults (MANGA personality, default accent/paper), while the user's persisted appearance preferences arrive asynchronously from DataStore. Users with a non-default personality see the app load in MANGA and then switch to their chosen theme a few seconds later — every single launch. Additionally, if the in-app dark-mode choice differs from the system setting, the startup flash shows the wrong light/dark mode too.

## What changed

`isAppearanceLoaded` flips **before the first frame renders**, and the splash covers the load:

1. **`MainViewModel`** gates on a single `combine` of the five theme-defining preferences the first themed frame reads: personality, accent, manga paper, AMOLED, and dark theme. Its first emission writes those fields and the flag in one `_state.update` — no happens-before gap between guard and guarded state. A 2 s watchdog releases the flag on defaults if a source never emits or the collector throws, so a wedged DataStore cannot hold the splash or leave desktop blank forever. (Bounded like the language read in `MainActivity`, though that one blocks synchronously before `setContent` while this releases the gate asynchronously.) `getThemeColor`/`getFontTheme` keep their collectors but do not gate the frame: nothing renders their values today. Three more first-frame reads stay outside the gate on purpose — `appLanguageTag` (the language read in `MainActivity` already blocks for it before `setContent`), `isScrollbarEnabled`, and `contentWidth` apply their own collectors right after the gate lifts; they don't define the theme, and gating on them would only delay the first frame.

2. **`Main.kt`** holds a plain frame instead of composing the navigation graph while the flag is down. The gate sits above the deep-link handlers on purpose: `NavHost` sets its graph only when it composes, so the deep-link effect must not run before the gate lifts — otherwise a cold-start link throws, and the link would also be silently dropped. When the flag flips, the effect runs with a set graph and consumes the link.

3. **`MainActivity`** holds the system splash with `setKeepOnScreenCondition { !mainViewModel.state.value.isAppearanceLoaded }` — the same `StateFlow` the Compose gate reads, so both gates share one source of truth with no mirrored flag. While held, draw requests are cancelled, so on Android the user goes **splash → their real theme** with no intermediate frame. Desktop has no splash system; there the plain pre-gate frame is the fallback.

4. The three startup preference reads (language on Android, language on desktop, appearance gate in `MainViewModel`) now share one `readStartupPreference` util — bounded wait, degrade on timeout/error, and a log line on every degradation so silent DataStore failures stay visible.

### Known limitation

If the gate times out (preferences not loaded within 2 s), the first frame paints the defaults until the real values arrive. This trades the old "wrong theme every launch" for "wrong theme only on an abnormally slow first load" — bounded, preferable to an unbounded hold, and self-correcting whenever the emission eventually arrives (a source that never emits at all keeps defaults until the next launch, rather than hanging the frame). If the collector itself throws after the gate has lifted (e.g. a corrupted DataStore stream), the five theme fields keep their last values for the rest of the session — a restart re-reads them; this matches the timeout degradation above in spirit but is not self-correcting mid-session.

## Validation

- `:composeApp:compileDebugKotlinAndroid`, `:composeApp:compileKotlinJvm`, `ktlintCheck` — all green on the final revision.
- Device-verified on an earlier revision of this branch (phone + tablet, light and dark modes, cold start): splash held ~1.7 s (system `Displayed +1.7s`), then released directly into the real themed UI with zero placeholder frames; dark mode followed the stored preference under `cmd uimode` toggling.
- The review fixes (gate placement, single-subscription combine, watchdog) are verified by compilation, lint, and code inspection (cold-start deep-link path traced through `NavHost` composition order). Device re-check of cold-start deep links on the final revision completed: `force-stop` → `githubstore://repo/...` VIEW intent lands on the repository detail page with no crash and no dropped link (multiple runs, 3–15 s UI sampling; crash buffer clean).

Display/startup wiring only — no schema, no persisted-data changes, no behavior change once preferences are loaded.




